### PR TITLE
L0: contract, design system, and validate/finalize implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Dependencies and build output.
+node_modules/
+dist/
+
 # Working specs / brainstorming artifacts — not part of the tracked living spec.
 # The durable governance record lives in design/decisions/.
 docs/superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Working specs / brainstorming artifacts — not part of the tracked living spec.
+# The durable governance record lives in design/decisions/.
+docs/superpowers/

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,64 @@
+# Governance
+
+evidence-cli is an open format that other frameworks will adopt. To keep it
+trustworthy and legible as it grows, this repo runs on one rule:
+
+> **The decision is the unit of work. Code is downstream of it.**
+
+This is itself a decision — [`design/decisions/0001-decisions-gate-code.md`](design/decisions/0001-decisions-gate-code.md).
+
+## The rules
+
+1. **No code without a decision.** Any change in behavior, schema, or contract
+   starts as a decision record in [`design/decisions/`](design/decisions). New
+   decision, or an amendment to an existing one.
+2. **No code change without updating the structure.** A pull request that changes
+   behavior without a corresponding decision (and, where relevant, an updated
+   [contract page](design/contract) or [schema](design/schemas)) is incomplete by
+   definition.
+3. **Full visibility.** Every decision records its **proposition**, the
+   **options** weighed, the **decision**, and the **reasoning** — all in the tree,
+   all rendered by the [viewer](design/web).
+4. **Schemas are the single source of truth.** The L0 JSON Schemas in
+   [`design/schemas/L0/`](design/schemas/L0) are consumed by *both* the validator
+   (`src/`) and the viewer (`design/web`). Docs cannot drift from the validator
+   because they are the same files. See
+   [decision 0024](design/decisions/0024-schemas-single-source-of-truth.md).
+
+## A decision record
+
+Each record is one markdown file with YAML frontmatter and a reasoning body. See
+[decision 0022](design/decisions/0022-decision-record-format.md) for the format.
+Minimum frontmatter:
+
+```yaml
+---
+id: <n>
+slug: <kebab-slug>
+title: <short title>
+status: proposed | accepted | superseded
+date: YYYY-MM-DD
+proposition: >
+  the question this decision answers
+options:
+  - id: <slug>
+    summary: <one line>
+    chosen: true | false
+decision: >
+  the choice, stated plainly
+governs:
+  - <path or field this decision shapes>
+feature: [<feature-id from design/features.yaml>]
+depends_on: [<ids of decisions this one builds on>]
+supersedes: []
+---
+
+## Reasoning
+why this choice, and why not the others.
+```
+
+## Changing a past decision
+
+Decisions are durable. To reverse one, add a **new** decision that records the new
+proposition and reasoning, set the old one's `status: superseded`, and list the
+old id in the new record's `supersedes`. History stays visible.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
 # evidence-cli
+
+**An open, framework-agnostic format for what a test run produced — and the CLI
+that seals and validates it.**
+
+One shape, whatever made it: a browser agent, a Playwright suite, a Jest run, an
+API check. An evidence pack is readable by a CI dashboard, an auditor, or a human
+without knowing the framework that wrote it.
+
+```bash
+npm i -g evidence-cli
+
+evidence finalize my-run.evidence/          # roll up totals, hash definitions, seal → .evidence (directory only)
+evidence index    my-run.evidence/          # (re)generate the optional human renders (summary.md / result.md)
+evidence validate my-run.evidence --profile L0   # check a directory OR a sealed .evidence zip
+```
+
+## What's in a pack
+
+A pack is a `<name>.evidence/` directory (which zips to a `<name>.evidence` file),
+anchored by a top-level `run.yaml`. At **L0** — the minimal profile — only three
+artifacts are load-bearing:
+
+```
+<name>.evidence/
+  run.yaml                 # required — manifest anchor (run identity, lifecycle, derived totals)
+  tests/<id>/
+    <definition>           # required, OPAQUE — the framework's own artifact (kane test.md, *.spec.ts, …)
+    result.yaml            # required — structured per-step outcomes
+```
+
+evidence-cli knows **nothing** about any framework's definition format. It
+references and hashes the definition; it never parses it. The format scales by
+*adding* optional files and profiles (L1–L3, browser, mobile, a11y, security) —
+never by rewriting the L0 core.
+
+## This repo is its own spec
+
+`evidence-cli` is governed by a living decision log. The
+[`design/`](design) directory holds the **decisions** (proposition → options →
+decision → reasoning), the **contract**, the **JSON Schemas** (the single source
+of truth, consumed by both the validator and the docs), and a **web viewer** that
+renders all of it.
+
+> The decision is the unit of work. Code is downstream of it. No code lands
+> without a decision; no change lands without updating the structure.
+
+See [`GOVERNANCE.md`](GOVERNANCE.md).
+
+## Browse the design locally
+
+```bash
+npm run docs        # serves the design/ viewer at a local URL
+```
+
+## Layout
+
+```
+evidence-cli/
+  design/
+    decisions/     # ADRs — every choice and its reasoning
+    contract/      # L0 pack layout, lifecycle, commands, config
+    schemas/L0/    # JSON Schema — single source of truth
+    web/           # local viewer (Vite/React)
+  src/             # validate, finalize, profile/config resolution  (TypeScript)
+  fixtures/        # valid-L0/, invalid-L0/  — conformance examples
+```
+
+## Status
+
+Early. The **`0.1` contract** is being defined, starting with its minimal
+**profile, L0**; richer profiles (L1–L3) follow on the *same* `0.1` contract.
+Version and profile are different axes: a profile only *adds* requirements and
+never changes the version, while a breaking change to an existing meaning bumps
+`evidence` to `0.2`. The contract and its reasoning are tracked in
+[`design/decisions/`](design/decisions) (see decision 0027).

--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,79 @@
+# Evidence — for **any** test framework
+
+**Evidence** is an open, framework-agnostic format for what a test run produced.
+One shape, whatever made it — a browser agent, a Playwright suite, a Jest run, an
+API check. A pack is readable by a CI dashboard, an auditor, or a human without
+knowing the framework that wrote it.
+
+This `design/` directory is the **living spec**. It is not documentation *about*
+the format that lives somewhere else — it *is* the format's source of truth, and
+the [web viewer](./web) renders it.
+
+## The four pillars
+
+| Pillar | What it holds |
+| --- | --- |
+| [`decisions/`](./decisions) | Every design decision as a record: **proposition → options → decision → reasoning**. Read these to understand *why*, not just *what*. |
+| [`contract/`](./contract) | The L0 contract in prose: pack layout, lifecycle & verdicts, commands & config. |
+| [`schemas/L0/`](./schemas/L0) | The L0 JSON Schemas — the **single source of truth**, consumed by both the validator and this viewer. |
+| [`web/`](./web) | A local site that renders all of the above. |
+
+## What L0 is
+
+L0 is the **minimal** profile. A pack is a `<name>.evidence/` directory (which
+zips to a `<name>.evidence` file) anchored by a top-level `run.yaml`. The only
+load-bearing artifacts are:
+
+- **`run.yaml`** — the run manifest (identity, lifecycle, derived totals).
+- **`tests/<id>/<definition>`** — what was tested, **opaque** to evidence-cli.
+- **`tests/<id>/result.yaml`** — what happened, as structured per-step outcomes.
+
+Everything else is optional and additive. The format scales by *adding* — L1, L2,
+L3 and orthogonal profiles never rewrite the L0 core. Profile and *version* are
+distinct axes: the `evidence` version (`"0.1"`) is the contract spanning every
+profile, and only a breaking change bumps it — adding a profile never does (see
+decision 0027).
+
+## Why a decision log gates the code
+
+evidence-cli will be open-sourced and adopted by frameworks we do not control. So
+the repo inverts the usual order: **the decision is the unit of work, and code is
+downstream of it.** No code lands without a decision; no code change lands without
+updating this structure. See [`GOVERNANCE.md`](../GOVERNANCE.md) and decision
+[0001 — Decisions gate code](./decisions/0001-decisions-gate-code.md).
+
+## Run the viewer
+
+```bash
+npm run docs        # from the repo root — serves the design/ viewer locally
+```
+
+## The shape at a glance
+
+```
+<name>.evidence/
+  run.yaml                 # required — manifest anchor
+  tests/<id>/
+    <definition>           # required, opaque (kane: test.md, Playwright: *.spec.ts)
+    result.yaml            # required — per-step outcomes
+```
+
+```yaml
+# run.yaml — verdict roll-up is DERIVED by `evidence finalize`
+evidence: "0.1"
+run_id: 2026-06-19-smoke-7f3a
+status: finalized          # running → finalized | aborted
+title: Nightly smoke
+totals: { tests: 5, passed: 2, failed: 2, broken: 1, skipped: 0 }
+```
+
+```yaml
+# tests/card-payment/result.yaml — verdict authored, structure parseable
+evidence: "0.1"
+test: card-payment
+status: broken             # passed | failed | broken | skipped
+definition: { path: test.md, sha256: "sha256:…" }   # sha256 added at finalize
+steps:
+  - { id: open-checkout, ordinal: 1, status: passed }
+  - { id: confirm-payment, ordinal: 3, status: broken }
+```

--- a/design/contract/01-pack-layout.md
+++ b/design/contract/01-pack-layout.md
@@ -1,0 +1,59 @@
+---
+title: Pack layout
+order: 1
+---
+
+# Pack layout (L0)
+
+An **evidence pack** is the unit of the format. It exists in two forms:
+
+- **Live** — a `<name>.evidence/` **directory**, written while a run is in flight.
+- **Sealed** — a `<name>.evidence` **file**: that directory zipped. A plain zip
+  with a known extension, like `.ipa` or `.epub`. Transport and seal only — the
+  bytes inside are identical to the directory.
+
+The sealed zip is **flat**: its entries are exactly the *contents* of the
+`<name>.evidence/` directory — `run.yaml` at the archive root, `tests/…` beside
+it, with **no** wrapping `<name>.evidence/` folder. "Top-level `run.yaml`"
+therefore means the same thing in both forms (directory root / archive root), so
+a reader resolves the anchor and every relative `definition.path` identically.
+The pack `<name>` lives only in the file name, never as an internal path segment.
+See decision [0028 — zip internal layout](#/decisions).
+
+**One pack = one run.** The top-level `run.yaml` is the **manifest anchor**: a
+directory (or zip) is a valid pack if and only if it has a top-level `run.yaml`.
+
+## The L0 tree
+
+```
+<name>.evidence/
+  run.yaml                 # required — the manifest anchor (run-level)
+  summary.md               # optional — auto-generated human TL;DR (never parsed)
+  tests/
+    <id>/                  # one directory per test; id = a slug or run id
+      <definition>         # required, OPAQUE — the framework's own artifact
+      result.yaml          # required — structured per-step outcomes
+      result.md            # optional — auto-generated render (never parsed)
+      summary.md           # optional — auto-generated per-test TL;DR
+```
+
+Only three artifacts are **load-bearing** at L0:
+
+| Artifact | Role |
+| --- | --- |
+| `run.yaml` | Run manifest + anchor. See the [run.yaml schema](#/contract). |
+| `tests/<id>/<definition>` | What was tested — **opaque** to evidence-cli; referenced and hashed, never parsed. |
+| `tests/<id>/result.yaml` | What happened — structured, parseable per-step outcomes. |
+
+Everything else (`summary.md`, `result.md`, any attachments) is **optional and
+additive**: auto-generated *from* the load-bearing data and never required.
+evidence-cli never depends on it and never parses opaque extras.
+
+## Framework-agnostic by construction
+
+evidence-cli knows **nothing** about any framework's definition format. The
+definition file may be `test.md` (kane), `login.spec.ts` (Playwright), or
+anything else. evidence-cli asserts the file exists and records its hash; it
+never reads the content. See decision
+[0002 — Framework-agnostic](#/decisions) and
+[0004 — Definition required but opaque](#/decisions).

--- a/design/contract/02-lifecycle.md
+++ b/design/contract/02-lifecycle.md
@@ -1,0 +1,54 @@
+---
+title: Lifecycle & verdicts
+order: 2
+---
+
+# Lifecycle & verdicts (L0)
+
+The format has **two independent axes**. Keeping them separate is deliberate:
+one describes the *run's progress*, the other describes *test outcomes*.
+
+## Run lifecycle — `run.yaml.status`
+
+```
+running  ──finalize──▶  finalized
+   │
+   └────────────────▶  aborted
+```
+
+- **`running`** — the run is in flight. `totals`, `ended`, and definition hashes
+  are **not yet authoritative**.
+- **`finalized`** — the pack is sealed. `finalize` has rolled up `totals`,
+  written each `definition.sha256`, set `ended`, and produced the `.evidence`
+  zip. This is the only authoritative state.
+- **`aborted`** — the run ended without sealing.
+
+This lifecycle is **not** a verdict. A run can be `finalized` and still contain
+`failed` tests.
+
+## Test verdict — `result.yaml.status` (and each step's `status`)
+
+The same four values are used at **test level and step level**:
+
+| Verdict | Meaning |
+| --- | --- |
+| `passed` | The oracle was satisfied. |
+| `failed` | The oracle was evaluated and **the product was wrong** (a real defect). |
+| `broken` | The oracle **could not be evaluated** — environment / infrastructure / test fault. |
+| `skipped` | Not executed. |
+
+The `failed` vs `broken` distinction is the heart of the model: it separates
+"the product is wrong" from "we couldn't tell." See decision
+[0006 — Verdict enum](#/decisions).
+
+## What `finalize` derives
+
+`finalize` is the operation that flips `running → finalized` and **derives**:
+
+- `run.yaml.totals` — the five-bucket roll-up over every `result.yaml` verdict.
+- each `result.yaml` `definition.sha256` — the content hash of the opaque
+  definition file declared at `definition.path`.
+
+Producers never hand-author these. See decisions
+[0011 — Totals derived by finalize](#/decisions) and
+[0005 — Definition located by path](#/decisions).

--- a/design/contract/03-commands.md
+++ b/design/contract/03-commands.md
@@ -1,0 +1,122 @@
+---
+title: Commands & config
+order: 3
+---
+
+# Commands & config (L0)
+
+Stage one ships three commands, all operating on the pack's internal tree. Only
+`validate` is container-agnostic: `finalize` and `index` take the **live**
+`<name>.evidence/` directory, while `validate` accepts **either** a directory or a
+sealed `.evidence` zip.
+
+| Command | Input | Mutates? |
+| --- | --- | --- |
+| `finalize` | live `<name>.evidence/` directory only | yes — derives + seals |
+| `index` | live `<name>.evidence/` directory only | yes — only optional `*.md` renders |
+| `validate` | a directory **or** a sealed `.evidence` zip | no — read-only |
+
+## `evidence finalize <dir>`
+
+Seals a live pack. Operates **only** on the `<name>.evidence/` directory — it will
+not finalize an already-sealed zip (exit `2`), since that pack is already
+finalized. See decision [0035 — finalize targets the live directory](#/decisions).
+
+1. Rolls up `run.yaml.totals` from every `tests/<id>/result.yaml` verdict.
+2. Computes and writes each `result.yaml` `definition.sha256` from the file at
+   `definition.path`.
+3. Sets `run.yaml.status: finalized` and `ended`.
+4. Seals the pack to a `<name>.evidence` zip — a **flat** archive whose entries are
+   the directory's contents (root-level `run.yaml`, `tests/…` beside it, no
+   wrapping folder). See decision [0028 — zip internal layout](#/decisions).
+
+## `evidence index <dir>`
+
+Regenerates the **optional** human renders — the run-level `summary.md` and each
+`tests/<id>/result.md` / `summary.md` — purely from the load-bearing `run.yaml` +
+`result.yaml` data. The output is never parsed, never load-bearing, and always
+reproducible: deleting and re-running `index` changes nothing material. It is kept
+separate from `finalize` so sealing stays about derivation + seal. See decision
+[0034 — index command](#/decisions).
+
+## `evidence validate <target> --profile L0`
+
+Checks a pack against a profile. Accepts a directory **or** a sealed zip.
+Validation is **status-gated**:
+
+| Run status | Checks |
+| --- | --- |
+| `running` / `aborted` | **Structure-only** — see the structure-only checks below. |
+| `finalized` | **Full seal** — the structure-only checks **plus** the full-seal checks below. |
+
+Beyond the JSON-Schema shape, the validator enforces these cross-checks
+(decision [0031](#/decisions)) — JSON Schema cannot express cross-file equality,
+sibling comparison, or filesystem facts:
+
+**Structure-only (every run status):**
+- the manifest anchor (`run.yaml`) and identity fields are present;
+- `result.test` equals its `tests/<id>/` directory name;
+- each test dir has a `result.yaml` and a declared `definition.path`, **and the
+  file at that path exists** (only the *hash* waits for finalize);
+- `definition.path` is contained — no `/`-prefix, no `..`, no escape;
+- step `ordinal`s are unique and strictly increasing (gaps allowed).
+
+**Full seal (adds, when `finalized`):**
+- `ended` and `totals` present, and `ended` ≥ `started`;
+- `totals` equals the rolled-up per-test verdicts, **and** `totals.tests` equals
+  the sum of the four verdict buckets;
+- every `definition.sha256` is present and hash-matches its file.
+
+A test `status` that disagrees with its steps is a **warning**, never a failure —
+the [test verdict is authored](#/decisions), so the validator checks, it does not
+judge.
+
+Proposed CLI conventions: exit `0` = valid, `1` = invalid, `2` = usage error;
+human-readable output by default, `--json` for machine consumption.
+
+See decisions [0017 — Commands](#/decisions),
+[0018 — Status-gated validation](#/decisions), and
+[0031 — Validator cross-checks](#/decisions).
+
+## Profiles (and how they relate to the `evidence` version)
+
+`L0` is the minimal profile. Higher and orthogonal profiles (L1–L3, browser,
+mobile, a11y, security) are **purely additive** — they add assertions and finding
+layers and never rewrite the L0 core.
+
+A **profile** is not the same axis as the **`evidence` version**. The version
+(`"0.1"`) is the *contract* — the field meanings — and one contract version spans
+the whole profile ladder. Adding a profile is additive and never changes the
+version; only a **breaking** change to an existing meaning bumps it (a
+version-pinned validator then cleanly rejects the newer pack rather than
+mis-reading it). See decision [0027 — Evidence version vs profiles](#/decisions).
+
+The active profile resolves as:
+
+```
+--profile flag  →  config.defaultProfile  →  built-in default (L0)
+```
+
+## Config
+
+evidence-cli reads `~/.testmuai/evidence/config.json` by default (branded under
+testmuai, **not** nested under kaneai — evidence-cli is its own entity). Override
+with the `EVIDENCE_CONFIG` env var or a `--config` flag. The config holds
+`defaultProfile` today and is extensible to multiple named profiles/configs.
+
+```jsonc
+// ~/.testmuai/evidence/config.json
+{
+  "defaultProfile": "L0"
+}
+```
+
+See decisions [0020 — Profile resolution](#/decisions) and
+[0021 — Config location](#/decisions).
+
+## Mounting into kane-cli
+
+evidence-cli is built in TypeScript/Node and exposes `validate`/`finalize` as
+library functions, so kane-cli mounts it **in-process** as `kane-cli evidence`
+with shared types and no subprocess boundary. See decision
+[0019 — Runtime](#/decisions).

--- a/design/decisions/0001-decisions-gate-code.md
+++ b/design/decisions/0001-decisions-gate-code.md
@@ -1,0 +1,59 @@
+---
+id: 1
+slug: decisions-gate-code
+title: Decisions gate code
+status: accepted
+date: 2026-06-26
+proposition: >
+  How do we keep this open-source format trustworthy and legible as it grows —
+  so that anyone, on any framework, can see not just WHAT the format is but WHY
+  every part of it is the way it is?
+options:
+  - id: decision-log-gates-code
+    summary: A versioned decision log is the source of truth; no code lands without a decision, no change lands without updating the structure.
+    chosen: true
+  - id: code-first-docs-later
+    summary: Write code, document after the fact.
+    chosen: false
+  - id: prose-spec
+    summary: Maintain a single prose spec document alongside the code.
+    chosen: false
+decision: >
+  The repo IS the spec. design/ holds decisions, contract, schemas and a web
+  viewer that renders them. Every change starts as a decision record; no code
+  lands without one; no code change lands without the structure being updated.
+governs:
+  - repo
+  - design/
+feature: [decision-system]
+depends_on: []
+supersedes: []
+---
+
+## Reasoning
+
+evidence-cli will be open-sourced and adopted by frameworks we do not control.
+A pile of code with stale comments — or a prose spec that drifts from the
+validator — would erode trust fast. So we invert the usual order: **the
+decision is the unit of work, and code is downstream of it.**
+
+This is self-hosted. This very rule is decision `0001`; the web viewer renders
+it next to every other decision so a newcomer can read the *reasoning* behind
+the format, not just its shape.
+
+Two structural consequences make drift impossible rather than merely
+discouraged:
+
+- The L0 schemas are the [single source of truth](0024-schemas-single-source-of-truth.md):
+  the validator and the docs render the *same* files.
+- Decisions declare what they `govern`, so the viewer can link a schema field
+  back to the decision that shaped it.
+
+## Consequences
+
+- A pull request that changes behavior without a corresponding decision record
+  (new or amended) is incomplete by definition.
+- "Full visibility" is not a slogan: the proposition, the options we weighed,
+  the choice, and the reasoning are all in the tree and all rendered.
+- The cost is discipline on small changes. We accept it — the audience is every
+  framework author who will ever evaluate whether to trust this format.

--- a/design/decisions/0002-framework-agnostic.md
+++ b/design/decisions/0002-framework-agnostic.md
@@ -1,0 +1,54 @@
+---
+id: 2
+slug: framework-agnostic
+title: Framework-agnostic by construction
+status: accepted
+date: 2026-06-26
+proposition: >
+  evidence-cli will be used by many test frameworks (kane, Playwright, Cypress,
+  Jest, API suites...). How much may the format know about any one of them?
+options:
+  - id: knows-nothing
+    summary: evidence-cli knows nothing about any framework's definition format; the definition artifact is opaque.
+    chosen: true
+  - id: neutral-definition-schema
+    summary: Define one neutral definition format every framework must translate into.
+    chosen: false
+  - id: kane-shaped
+    summary: Model the format around kane's test.md and let others adapt.
+    chosen: false
+decision: >
+  evidence-cli knows NOTHING about any framework's test definition. It never
+  parses test.md, .spec.ts, `## objective`, or any native artifact. The
+  definition is referenced and hashed, never read.
+governs:
+  - design/schemas/L0/result.schema.json#/properties/definition
+feature: [definition]
+depends_on: []
+supersedes: []
+---
+
+## Reasoning
+
+The value of evidence is that it is the *same* shape no matter what produced
+it — a CI dashboard, an auditor, or a human can read a pack without knowing the
+framework. The moment the format encodes one framework's concepts, it stops
+being neutral and every other framework becomes a second-class citizen.
+
+So the per-test "definition" is [required but opaque](0004-definition-required-but-opaque.md):
+evidence-cli asserts it exists and records its hash, but its bytes are the
+framework's business. kane points `definition.path` at `test.md`; Playwright
+points it at `login.spec.ts`. evidence-cli treats both identically.
+
+This is also why step `kind` is an [open string](0009-step-kind-open-string.md)
+and metric `type` is [open](0012-typed-free-form-metrics.md): a unit test has no
+`navigate` step and an API suite computes no `determinism`. The format provides
+*structure*, the framework provides *vocabulary*.
+
+## Consequences
+
+- Nothing kane-specific may enter `design/schemas/` or `src/`. Reviews enforce this.
+- Cross-framework comparability is structural (same files, same enums), not
+  semantic (we do not claim a kane "assertion" equals a Cypress one).
+- Frameworks integrate by *emitting* the format, not by translating into a
+  foreign definition schema.

--- a/design/decisions/0002-framework-agnostic.md
+++ b/design/decisions/0002-framework-agnostic.md
@@ -22,7 +22,7 @@ decision: >
   parses test.md, .spec.ts, `## objective`, or any native artifact. The
   definition is referenced and hashed, never read.
 governs:
-  - design/schemas/L0/result.schema.json#/properties/definition
+  - src/schemas/0.1/L0/result.schema.json#/properties/definition
 feature: [definition]
 depends_on: []
 supersedes: []

--- a/design/decisions/0003-pack-model-and-manifest-anchor.md
+++ b/design/decisions/0003-pack-model-and-manifest-anchor.md
@@ -24,7 +24,7 @@ decision: >
   identifies a valid pack. One pack = one run. `validate` accepts either form.
 governs:
   - design/contract
-  - design/schemas/L0/run.schema.json
+  - src/schemas/0.1/L0/run.schema.json
 feature: [pack-format, finalize]
 depends_on: []
 supersedes: []

--- a/design/decisions/0003-pack-model-and-manifest-anchor.md
+++ b/design/decisions/0003-pack-model-and-manifest-anchor.md
@@ -1,0 +1,55 @@
+---
+id: 3
+slug: pack-model-and-manifest-anchor
+title: Pack model and the run.yaml manifest anchor
+status: accepted
+date: 2026-06-26
+proposition: >
+  How is an evidence pack physically structured and transported, and what single
+  thing identifies a directory or file as a valid pack?
+options:
+  - id: dir-zip-with-anchor
+    summary: A `<name>.evidence/` directory (live) that zips to a `<name>.evidence` file (sealed), like .ipa/.epub; run.yaml at the top is the manifest anchor.
+    chosen: true
+  - id: single-file-binary
+    summary: A bespoke single-file binary container.
+    chosen: false
+  - id: database
+    summary: A SQLite/embedded DB per run.
+    chosen: false
+decision: >
+  A pack is a `<name>.evidence/` directory while being written, and a
+  `<name>.evidence` zip once sealed (a plain zip with a known extension, like
+  .ipa or .epub). The top-level `run.yaml` is the manifest anchor: its presence
+  identifies a valid pack. One pack = one run. `validate` accepts either form.
+governs:
+  - design/contract
+  - design/schemas/L0/run.schema.json
+feature: [pack-format, finalize]
+depends_on: []
+supersedes: []
+---
+
+## Reasoning
+
+Zip-with-a-known-extension is a boring, proven container model (`.ipa`, `.jar`,
+`.docx`, `.epub`). It gives us a single portable artifact for transport and a
+plain directory for live writing — the same bytes, just archived. No new
+container format to specify, and every language already has a zip reader.
+
+We need one unambiguous "is this a pack?" check. Rather than a separate
+`manifest.json`, the run-level [`run.yaml`](0010-run-yaml-mandatory-cut.md) *is*
+the anchor: a directory (or zip) with a top-level `run.yaml` is a pack. This
+keeps the format flat — there is exactly one required run-level file, and it is
+also the thing that names the run.
+
+Because the contract is defined over the *internal tree*, the zip is pure
+transport/sealing. `validate` therefore accepts both a `*.evidence/` directory
+and a `.evidence` zip and reads entries the same way.
+
+## Consequences
+
+- The validator must transparently read both a directory and a zip.
+- Sealing (producing the zip) is part of [`finalize`](0017-commands-validate-and-finalize.md),
+  which is also where the live→sealed [lifecycle](0007-run-lifecycle.md) flips.
+- "One pack = one run" keeps `run_id` and the pack identity 1:1.

--- a/design/decisions/0004-definition-required-but-opaque.md
+++ b/design/decisions/0004-definition-required-but-opaque.md
@@ -22,7 +22,7 @@ decision: >
   it exists and records its content hash, but treats the bytes as opaque — it
   never parses them.
 governs:
-  - design/schemas/L0/result.schema.json#/properties/definition
+  - src/schemas/0.1/L0/result.schema.json#/properties/definition
 feature: [definition]
 depends_on: [2]
 supersedes: []

--- a/design/decisions/0004-definition-required-but-opaque.md
+++ b/design/decisions/0004-definition-required-but-opaque.md
@@ -1,0 +1,50 @@
+---
+id: 4
+slug: definition-required-but-opaque
+title: The definition is required but opaque
+status: accepted
+date: 2026-06-26
+proposition: >
+  Every test has a "definition" (what it tests) authored in the framework's own
+  format. Since evidence-cli cannot know that format, how should L0 treat it?
+options:
+  - id: required-but-opaque
+    summary: Each test dir MUST contain a definition file; evidence-cli checks presence (and hash) but never parses content.
+    chosen: true
+  - id: optional
+    summary: The definition is optional; L0 requires only run.yaml + result.yaml.
+    chosen: false
+  - id: neutral-schema
+    summary: evidence-cli defines its own neutral definition schema every framework maps into.
+    chosen: false
+decision: >
+  Every test directory MUST contain a definition artifact. evidence-cli asserts
+  it exists and records its content hash, but treats the bytes as opaque — it
+  never parses them.
+governs:
+  - design/schemas/L0/result.schema.json#/properties/definition
+feature: [definition]
+depends_on: [2]
+supersedes: []
+---
+
+## Reasoning
+
+Two pulls: every result should trace to *what was tested* (so "required"), but
+evidence-cli must stay [framework-agnostic](0002-framework-agnostic.md) (so
+"opaque"). Required-but-opaque satisfies both — the pack always records a
+definition, and evidence-cli never needs to understand it.
+
+Making it optional would let a pack validate with no record of what it tested —
+weak provenance. Defining a neutral definition schema would force every
+framework to translate its native artifact and would smuggle test semantics back
+into a format that is meant to have none.
+
+The definition is [located by a path the framework pre-declares](0005-definition-located-by-path.md),
+so evidence-cli never has to guess a filename.
+
+## Consequences
+
+- A finalized test dir without its declared definition file fails validation.
+- evidence-cli records `definition.sha256` for integrity but offers no parsing,
+  search, or rendering of definition content — that is the framework's job.

--- a/design/decisions/0005-definition-located-by-path.md
+++ b/design/decisions/0005-definition-located-by-path.md
@@ -1,0 +1,49 @@
+---
+id: 5
+slug: definition-located-by-path
+title: Definition located by a pre-declared path; finalize adds the hash
+status: accepted
+date: 2026-06-26
+proposition: >
+  If the definition is opaque and its filename varies by framework (test.md,
+  login.spec.ts, ...), how does evidence-cli locate it to assert presence and
+  record its hash?
+options:
+  - id: framework-declares-path
+    summary: The framework writes `definition.path` in result.yaml (its native filename); `finalize` computes and adds `sha256`.
+    chosen: true
+  - id: reserved-names
+    summary: Reserve known filenames; whatever non-reserved file remains is the definition.
+    chosen: false
+  - id: flag
+    summary: Pass the definition filename to `finalize` via a flag.
+    chosen: false
+decision: >
+  Before finalize, the framework declares `definition: { path: <native-name> }`
+  in result.yaml. `evidence finalize` reads that path, computes the content hash,
+  and writes `definition.sha256` back. evidence-cli never guesses a filename.
+governs:
+  - design/schemas/L0/result.schema.json#/properties/definition
+feature: [definition, finalize]
+depends_on: [4]
+supersedes: []
+---
+
+## Reasoning
+
+The framework owns naming, so the framework should name the file. A pre-declared
+`path` keeps evidence-cli [agnostic](0002-framework-agnostic.md): it does not
+reserve names, infer from directory contents, or push naming knowledge into the
+command line. The pack is self-describing.
+
+Splitting authorship is deliberate: `path` is authored by the producer (it knows
+its own filename); `sha256` is derived by [`finalize`](0017-commands-validate-and-finalize.md)
+(integrity is evidence-cli's concern, computed when the pack is sealed). A
+finalized pack therefore carries both; a still-`running` pack may carry only
+`path`.
+
+## Consequences
+
+- `result.yaml` schema requires `definition.path`; `sha256` is added at finalize.
+- `validate` on a [finalized](0018-status-gated-validation.md) pack checks that
+  the file at `path` exists and that its hash matches `sha256`.

--- a/design/decisions/0005-definition-located-by-path.md
+++ b/design/decisions/0005-definition-located-by-path.md
@@ -23,7 +23,7 @@ decision: >
   in result.yaml. `evidence finalize` reads that path, computes the content hash,
   and writes `definition.sha256` back. evidence-cli never guesses a filename.
 governs:
-  - design/schemas/L0/result.schema.json#/properties/definition
+  - src/schemas/0.1/L0/result.schema.json#/properties/definition
 feature: [definition, finalize]
 depends_on: [4]
 supersedes: []

--- a/design/decisions/0006-verdict-enum.md
+++ b/design/decisions/0006-verdict-enum.md
@@ -1,0 +1,53 @@
+---
+id: 6
+slug: verdict-enum
+title: Verdict enum — passed, failed, broken, skipped
+status: accepted
+date: 2026-06-26
+proposition: >
+  What verdict vocabulary does a test (and a step) use, and must it distinguish
+  "the product is wrong" from "we couldn't tell"?
+options:
+  - id: four-value-allure-style
+    summary: passed | failed | broken | skipped, where broken = oracle could not be evaluated.
+    chosen: true
+  - id: pass-fail
+    summary: Just passed | failed.
+    chosen: false
+  - id: add-unknown-running
+    summary: Add a fifth value like unknown/running.
+    chosen: false
+decision: >
+  The verdict enum is `passed | failed | broken | skipped`, used identically at
+  test level and step level. `failed` = the oracle was evaluated and the product
+  was wrong (a real defect). `broken` = the oracle could NOT be evaluated
+  (environment / infrastructure / test fault). `skipped` = not executed.
+governs:
+  - design/schemas/L0/result.schema.json#/properties/status
+  - design/schemas/L0/result.schema.json#/$defs/step/properties/status
+feature: [result-model]
+depends_on: []
+supersedes: []
+---
+
+## Reasoning
+
+Conflating "the product is broken" with "we couldn't run the check" destroys the
+signal a results format exists to carry. An auditor reading a pack needs to know
+whether a red test means a bug or a flaky environment. The four-value model
+(as popularized by Allure) draws exactly that line: `broken` is an oracle that
+could not render a judgment, distinct from `failed` which is a judgment against
+the product.
+
+Using the same four values at step and test level keeps the format small and
+lets a test verdict be reasoned about against its steps without a second
+vocabulary. Run *lifecycle* (running/finalized/aborted) is a
+[separate enum](0007-run-lifecycle.md) on `run.yaml` — it is not a verdict, so it
+does not belong here.
+
+## Consequences
+
+- `result.yaml` test `status` and each step `status` share this enum.
+- `run.yaml.totals` rolls up counts across exactly these four buckets.
+- The forensic detail explaining a `failed`/`broken` step (expected/actual/
+  defect) is [optional at L0](0015-result-yaml-mandatory-cut.md).

--- a/design/decisions/0006-verdict-enum.md
+++ b/design/decisions/0006-verdict-enum.md
@@ -23,8 +23,8 @@ decision: >
   was wrong (a real defect). `broken` = the oracle could NOT be evaluated
   (environment / infrastructure / test fault). `skipped` = not executed.
 governs:
-  - design/schemas/L0/result.schema.json#/properties/status
-  - design/schemas/L0/result.schema.json#/$defs/step/properties/status
+  - src/schemas/0.1/L0/result.schema.json#/properties/status
+  - src/schemas/0.1/L0/result.schema.json#/$defs/step/properties/status
 feature: [result-model]
 depends_on: []
 supersedes: []

--- a/design/decisions/0007-run-lifecycle.md
+++ b/design/decisions/0007-run-lifecycle.md
@@ -1,0 +1,49 @@
+---
+id: 7
+slug: run-lifecycle
+title: Run lifecycle — running, finalized, aborted
+status: accepted
+date: 2026-06-26
+proposition: >
+  A pack is written while a run is in flight and read after it ends. How do we
+  represent that live-vs-sealed state, and what does it imply for authority of
+  the data?
+options:
+  - id: lifecycle-enum
+    summary: run.status is running → finalized | aborted, distinct from verdicts; finalize seals the pack.
+    chosen: true
+  - id: none
+    summary: No lifecycle; a pack is always assumed complete.
+    chosen: false
+  - id: reuse-verdict
+    summary: Reuse the verdict enum for run state.
+    chosen: false
+decision: >
+  `run.yaml.status` is a lifecycle: `running → finalized | aborted`. It is NOT a
+  verdict. While `running`, totals/index/hashes are not authoritative; `finalize`
+  seals them. `aborted` is a run that ended without sealing.
+governs:
+  - design/schemas/L0/run.schema.json#/properties/status
+feature: [run-model]
+depends_on: []
+supersedes: []
+---
+
+## Reasoning
+
+Evidence is written incrementally, so a reader must be able to tell a mid-flight
+pack from a sealed one. A dedicated lifecycle makes "live vs sealed" explicit and
+keeps it cleanly separate from test [verdicts](0006-verdict-enum.md) — a run can
+be `finalized` while containing `failed` tests; the two axes are independent.
+
+The lifecycle has teeth: while `running`, derived data (`totals`, definition
+hashes) is not yet authoritative, so the [validator is status-gated](0018-status-gated-validation.md)
+and only demands the sealed set once `status: finalized`. `aborted` records that
+a run stopped without a clean seal — useful signal, not an error to hide.
+
+## Consequences
+
+- [`finalize`](0017-commands-validate-and-finalize.md) is the operation that
+  flips `running → finalized` and seals derived data atomically.
+- The run.yaml schema conditionally requires `ended` and `totals` only when
+  `status: finalized`.

--- a/design/decisions/0007-run-lifecycle.md
+++ b/design/decisions/0007-run-lifecycle.md
@@ -23,7 +23,7 @@ decision: >
   verdict. While `running`, totals/index/hashes are not authoritative; `finalize`
   seals them. `aborted` is a run that ended without sealing.
 governs:
-  - design/schemas/L0/run.schema.json#/properties/status
+  - src/schemas/0.1/L0/run.schema.json#/properties/status
 feature: [run-model]
 depends_on: []
 supersedes: []

--- a/design/decisions/0008-steps-execution-derived.md
+++ b/design/decisions/0008-steps-execution-derived.md
@@ -1,0 +1,53 @@
+---
+id: 8
+slug: steps-execution-derived
+title: Steps are execution-derived and may be empty
+status: accepted
+date: 2026-06-26
+proposition: >
+  Where do a test's steps come from, what granularity do they have, and must
+  they mirror the definition?
+options:
+  - id: execution-derived-producer-choice
+    summary: steps[] are ordered execution outcomes; the framework chooses granularity; may be empty; need not mirror the definition.
+    chosen: true
+  - id: mirror-definition
+    summary: steps must mirror the structure of the definition.
+    chosen: false
+  - id: fixed-granularity
+    summary: evidence-cli fixes what a step is.
+    chosen: false
+decision: >
+  `steps[]` is an ordered list of execution outcomes. The framework decides what
+  a step is and how granular it is. The array MAY be empty (a unit or API test
+  may have no sub-steps). evidence-cli does not require steps to mirror the
+  definition.
+governs:
+  - design/schemas/L0/result.schema.json#/properties/steps
+feature: [result-model]
+depends_on: [6, 2]
+supersedes: []
+---
+
+## Reasoning
+
+Steps describe *what happened during execution*, not the structure of the test's
+intent. A browser run yields `navigate`/`input`/`assertion` actions; a unit test
+yields a single pass/fail. Forcing steps to mirror the definition, or fixing a
+granularity, would re-introduce framework assumptions the format is built to
+avoid. So granularity is the producer's choice and the array can be empty.
+
+Because steps need not mirror the definition (which is
+[opaque](0004-definition-required-but-opaque.md) anyway), the test
+[`status` is authored](0016-test-status-authored.md) rather than computed from
+steps — derivation isn't always possible when `steps[]` is empty.
+
+For the kane framework specifically (a consumer, not the contract): steps come
+from the execution trace (`action.ndjson`), and the run-level `## objective` is
+*test-level intent* that lives inside the opaque definition — it is not a step.
+
+## Consequences
+
+- The result schema allows `steps: []`.
+- Step `kind` is an [open string](0009-step-kind-open-string.md), consistent with
+  granularity being the producer's call.

--- a/design/decisions/0008-steps-execution-derived.md
+++ b/design/decisions/0008-steps-execution-derived.md
@@ -23,7 +23,7 @@ decision: >
   may have no sub-steps). evidence-cli does not require steps to mirror the
   definition.
 governs:
-  - design/schemas/L0/result.schema.json#/properties/steps
+  - src/schemas/0.1/L0/result.schema.json#/properties/steps
 feature: [result-model]
 depends_on: [6, 2]
 supersedes: []

--- a/design/decisions/0009-step-kind-open-string.md
+++ b/design/decisions/0009-step-kind-open-string.md
@@ -20,7 +20,7 @@ decision: >
   not required to declare a `kind` (a unit/API step may have none). Frameworks
   coin their own kinds.
 governs:
-  - design/schemas/L0/result.schema.json#/$defs/step/properties/kind
+  - src/schemas/0.1/L0/result.schema.json#/$defs/step/properties/kind
 feature: [result-model]
 depends_on: [2, 8]
 supersedes: []

--- a/design/decisions/0009-step-kind-open-string.md
+++ b/design/decisions/0009-step-kind-open-string.md
@@ -1,0 +1,49 @@
+---
+id: 9
+slug: step-kind-open-string
+title: Step kind is an open string
+status: accepted
+date: 2026-06-26
+proposition: >
+  A step has a `kind` (navigate, input, assertion, ...). Should evidence-cli
+  enforce a fixed vocabulary or leave it open?
+options:
+  - id: open-string
+    summary: kind is an OPTIONAL open string; when present it must be non-empty; evidence-cli never checks its vocabulary.
+    chosen: true
+  - id: fixed-enum
+    summary: evidence-cli ships a fixed neutral enum and rejects unknown kinds.
+    chosen: false
+decision: >
+  `kind` is OPTIONAL. When a step carries it, it must be a non-empty string;
+  evidence-cli validates that non-emptiness but never the vocabulary. A step is
+  not required to declare a `kind` (a unit/API step may have none). Frameworks
+  coin their own kinds.
+governs:
+  - design/schemas/L0/result.schema.json#/$defs/step/properties/kind
+feature: [result-model]
+depends_on: [2, 8]
+supersedes: []
+---
+
+## Reasoning
+
+`navigate | input | assertion` are browser-automation kinds. A Jest unit test or
+an API suite has none of them. Hard-coding that enum would quietly make the
+format browser-shaped and demote every other framework — the opposite of
+[framework-agnostic](0002-framework-agnostic.md).
+
+So the format supplies the *slot* (`kind`) and the framework supplies the
+*vocabulary*. evidence-cli only checks the slot, *when filled*, is non-empty —
+it never requires the slot nor inspects the value. This mirrors the same choice
+for metric [`type`](0012-typed-free-form-metrics.md): structure is fixed,
+vocabulary is open. `kind` sits among the optional step fields of the
+[L0 mandatory cut](0015-result-yaml-mandatory-cut.md) — only `id`, `ordinal`,
+and `status` are required on a step.
+
+## Consequences
+
+- The schema does NOT list `kind` in a step's `required`; when present it must be
+  a non-empty string, nothing more.
+- The contract docs may *suggest* a common set (navigate/input/assertion/wait/
+  api/setup) without enforcing it.

--- a/design/decisions/0010-run-yaml-mandatory-cut.md
+++ b/design/decisions/0010-run-yaml-mandatory-cut.md
@@ -23,7 +23,7 @@ decision: >
   DERIVED by finalize. `metrics` and `environment` are optional. `lineage` is
   deferred.
 governs:
-  - design/schemas/L0/run.schema.json#/required
+  - src/schemas/0.1/L0/run.schema.json#/required
 feature: [run-model]
 depends_on: [3, 7]
 supersedes: []

--- a/design/decisions/0010-run-yaml-mandatory-cut.md
+++ b/design/decisions/0010-run-yaml-mandatory-cut.md
@@ -1,0 +1,52 @@
+---
+id: 10
+slug: run-yaml-mandatory-cut
+title: run.yaml mandatory cut for L0 v0.1
+status: accepted
+date: 2026-06-26
+proposition: >
+  Of all the fields a run.yaml can carry, which are mandatory at L0 v0.1 — the
+  "minimal" profile?
+options:
+  - id: small-identity-core
+    summary: MUST = evidence, run_id, status, started, title; ended/totals required once finalized; metrics/environment optional; lineage deferred.
+    chosen: true
+  - id: id-only
+    summary: Only an id is required.
+    chosen: false
+  - id: everything
+    summary: Require the full rich shape.
+    chosen: false
+decision: >
+  run.yaml MUST carry `evidence`, `run_id`, `status`, `started`, `title`.
+  `ended` and `totals` are required once `status: finalized`. `totals` is
+  DERIVED by finalize. `metrics` and `environment` are optional. `lineage` is
+  deferred.
+governs:
+  - design/schemas/L0/run.schema.json#/required
+feature: [run-model]
+depends_on: [3, 7]
+supersedes: []
+---
+
+## Reasoning
+
+L0 is the *minimal* profile: require the smallest core that still makes a pack
+useful and identifiable, and let everything else be optional or arrive at a
+higher level. Identity and lifecycle are non-negotiable — without
+`evidence`/`run_id`/`status`/`started`/`title` you cannot version, name, place,
+or time a run, or tell live from sealed.
+
+`ended` and `totals` only exist once a run is sealed, so they are required
+[conditionally on `finalized`](0018-status-gated-validation.md), not always —
+otherwise a legitimately `running` pack would fail to validate. `totals` is
+[derived by finalize](0011-totals-derived-by-finalize.md), never hand-authored.
+`metrics` and `environment` are framework-dependent and therefore
+[optional](0013-environment-optional.md). `lineage` is
+[deferred](0014-lineage-deferred.md) to keep v0.1 minimal.
+
+## Consequences
+
+- The run schema's base `required` is the five-field identity/lifecycle core; an
+  `if/then` adds `ended`+`totals` when finalized.
+- Unknown top-level keys are permitted (forward-compatibility for higher levels).

--- a/design/decisions/0011-totals-derived-by-finalize.md
+++ b/design/decisions/0011-totals-derived-by-finalize.md
@@ -1,0 +1,44 @@
+---
+id: 11
+slug: totals-derived-by-finalize
+title: Totals are derived by finalize, not authored
+status: accepted
+date: 2026-06-26
+proposition: >
+  Who is responsible for the run-level totals — does the framework author them,
+  or does evidence-cli compute them?
+options:
+  - id: finalize-derives
+    summary: evidence finalize rolls totals up from every result.yaml.
+    chosen: true
+  - id: framework-authors
+    summary: The framework writes totals into run.yaml itself.
+    chosen: false
+decision: >
+  `evidence finalize` computes `run.yaml.totals` by rolling up the verdicts of
+  every tests/<id>/result.yaml. Totals are not hand-authored, and are required
+  once the run is finalized.
+governs:
+  - design/schemas/L0/run.schema.json#/properties/totals
+feature: [run-model, finalize]
+depends_on: [6, 7]
+supersedes: []
+---
+
+## Reasoning
+
+Totals authored by hand drift from the per-test truth — a miscount, a forgotten
+update, a copy-paste. Making evidence-cli the single computer of totals
+guarantees the run-level summary always agrees with the per-test
+[verdicts](0006-verdict-enum.md) it summarizes. The per-test `result.yaml` files
+are the source; totals are a projection of them.
+
+This is why totals only become authoritative at `finalize`: while a run is
+[`running`](0007-run-lifecycle.md), tests are still arriving, so any total would
+be provisional. `finalize` seals the projection at the moment the run completes.
+
+## Consequences
+
+- `finalize` reads all result.yaml verdicts and writes the five-bucket totals.
+- `validate` on a finalized pack checks that totals match the rolled-up verdicts;
+  a mismatch is an error.

--- a/design/decisions/0011-totals-derived-by-finalize.md
+++ b/design/decisions/0011-totals-derived-by-finalize.md
@@ -19,7 +19,7 @@ decision: >
   every tests/<id>/result.yaml. Totals are not hand-authored, and are required
   once the run is finalized.
 governs:
-  - design/schemas/L0/run.schema.json#/properties/totals
+  - src/schemas/0.1/L0/run.schema.json#/properties/totals
 feature: [run-model, finalize]
 depends_on: [6, 7]
 supersedes: []

--- a/design/decisions/0012-typed-free-form-metrics.md
+++ b/design/decisions/0012-typed-free-form-metrics.md
@@ -1,0 +1,57 @@
+---
+id: 12
+slug: typed-free-form-metrics
+title: Typed free-form metrics
+status: accepted
+date: 2026-06-26
+proposition: >
+  Runs carry metrics (pass_rate, determinism, tokens, ...). How are they
+  represented so any framework can define its own, while a reader still knows how
+  to interpret each number?
+options:
+  - id: object-per-metric
+    summary: Each metric is an object with value + type (+ optional unit/label).
+    chosen: true
+  - id: typed-registry
+    summary: Flat values plus a sibling block declaring each metric's type.
+    chosen: false
+  - id: namespaced-by-type
+    summary: Group metrics under their type.
+    chosen: false
+decision: >
+  `metrics` is an open map. Each metric is an object `{ value, type }` (with
+  optional `unit`/`label`). `type` is an open string declared by the producer.
+  Metrics are FACTS, never verdicts.
+governs:
+  - design/schemas/L0/run.schema.json#/properties/metrics
+feature: [run-model]
+depends_on: [2, 6]
+supersedes: []
+---
+
+## Reasoning
+
+Two requirements pull together here: frameworks must be able to coin their own
+metrics ([agnostic](0002-framework-agnostic.md)), but a bare number is
+uninterpretable — is `0.9` a percentage, a ratio, a count? Attaching a `type` to
+each metric makes every metric self-describing without evidence-cli knowing the
+metric in advance. The object-per-metric shape keeps a metric's identity, value,
+and type in one place rather than split across sibling blocks.
+
+`type` is an [open string](0009-step-kind-open-string.md) for the same reason
+`kind` is: the format fixes the *structure*, the framework supplies the
+*vocabulary*. evidence-cli validates that `value` and `type` are present, not
+what `type` says.
+
+Metrics are explicitly facts, not judgments. The verdict lives only in
+[`status`/`totals`](0006-verdict-enum.md); `metrics` never carries a pass/fail
+meaning. This keeps the one place a pack says "good or bad" unambiguous. For the
+same reason a metric `value` is `number | integer | string` and **not** boolean:
+a bare `true`/`false` reads as a verdict, which is exactly what a metric must
+never be. A producer that wants a flag emits it as a typed string.
+
+## Consequences
+
+- The run schema models `metrics` as `additionalProperties` → `{ value, type, ... }`,
+  with `value` constrained to `number | integer | string` (no boolean).
+- A non-browser framework simply emits a different metric set; nothing is required.

--- a/design/decisions/0012-typed-free-form-metrics.md
+++ b/design/decisions/0012-typed-free-form-metrics.md
@@ -23,7 +23,7 @@ decision: >
   optional `unit`/`label`). `type` is an open string declared by the producer.
   Metrics are FACTS, never verdicts.
 governs:
-  - design/schemas/L0/run.schema.json#/properties/metrics
+  - src/schemas/0.1/L0/run.schema.json#/properties/metrics
 feature: [run-model]
 depends_on: [2, 6]
 supersedes: []

--- a/design/decisions/0013-environment-optional.md
+++ b/design/decisions/0013-environment-optional.md
@@ -24,7 +24,7 @@ decision: >
   checked only for being an object; nothing inside it is required at L0. A
   non-browser framework may omit model/surfaces — or the whole block — entirely.
 governs:
-  - design/schemas/L0/run.schema.json#/properties/environment
+  - src/schemas/0.1/L0/run.schema.json#/properties/environment
 feature: [run-model]
 depends_on: [10, 2]
 supersedes: []

--- a/design/decisions/0013-environment-optional.md
+++ b/design/decisions/0013-environment-optional.md
@@ -1,0 +1,51 @@
+---
+id: 13
+slug: environment-optional
+title: Environment is an optional block
+status: accepted
+date: 2026-06-26
+proposition: >
+  run.yaml can carry an `environment` block (producer, model, surfaces, ci).
+  What is its status at L0 v0.1?
+options:
+  - id: optional-block
+    summary: environment is allowed and validated if present, but nothing inside is required.
+    chosen: true
+  - id: producer-required
+    summary: Require environment.producer{name,version}.
+    chosen: false
+  - id: drop
+    summary: Defer environment entirely, like lineage.
+    chosen: false
+decision: >
+  `environment` is optional and is an OPEN map of key:value pairs. A few keys are
+  documented as conventional (`producer`, `model`, `surfaces`, `ci`), but none is
+  required and any additional key:value pairs are allowed. If present it is
+  checked only for being an object; nothing inside it is required at L0. A
+  non-browser framework may omit model/surfaces — or the whole block — entirely.
+governs:
+  - design/schemas/L0/run.schema.json#/properties/environment
+feature: [run-model]
+depends_on: [10, 2]
+supersedes: []
+---
+
+## Reasoning
+
+`environment` is genuinely framework- and context-dependent: a Jest run has no
+`model` or `surfaces`; a local run has no `ci`. Mandating any sub-field would
+either be meaningless for some producers or push browser/agent assumptions into
+the neutral core. So at L0 the whole block is optional, kept available for
+producers that have provenance to record.
+
+We considered requiring `producer{name,version}` for guaranteed provenance, but
+chose minimalism for v0.1 — provenance can be promoted to required at a higher
+level without breaking L0 packs (the format scales by adding requirements, never
+by rewriting). Fully dropping it (like [lineage](0014-lineage-deferred.md)) would
+needlessly discard a useful, harmless slot many producers will want.
+
+## Consequences
+
+- The run schema defines `environment` as an open object: known optional sub-keys
+  (`producer`/`model`/`surfaces`/`ci`) are documented, none is required, and
+  arbitrary additional key:value pairs are permitted.

--- a/design/decisions/0014-lineage-deferred.md
+++ b/design/decisions/0014-lineage-deferred.md
@@ -1,0 +1,43 @@
+---
+id: 14
+slug: lineage-deferred
+title: Lineage is deferred past v0.1
+status: accepted
+date: 2026-06-26
+proposition: >
+  Runs can chain or split (continues_from / part). Should lineage be part of L0
+  v0.1?
+options:
+  - id: defer
+    summary: Leave lineage out of v0.1; reintroduce it later as an additive field.
+    chosen: true
+  - id: include-now
+    summary: Include lineage in L0 now.
+    chosen: false
+decision: >
+  Lineage (`continues_from`, `part`) is out of scope for v0.1. It will return
+  later as a purely additive run.yaml field.
+governs:
+  - design/contract
+feature: [run-model]
+depends_on: [10]
+supersedes: []
+---
+
+## Reasoning
+
+L0 is the minimal first step. Run chaining/splitting is real but not needed to
+make a single pack useful, identifiable, and valid — which is all L0 must
+deliver. The format is designed to scale by *adding* optional fields, never by
+migrating or rewriting, so deferring lineage costs nothing: it can be introduced
+later without invalidating any L0 pack.
+
+Keeping v0.1 small also keeps the [validator](0017-commands-validate-and-finalize.md)
+and the [schemas](0024-schemas-single-source-of-truth.md) easy to reason about
+while the format finds its feet.
+
+## Consequences
+
+- `lineage` is not in the L0 run schema. Unknown top-level keys are tolerated, so
+  a producer emitting lineage early will not be rejected — it simply is not
+  validated at L0.

--- a/design/decisions/0015-result-yaml-mandatory-cut.md
+++ b/design/decisions/0015-result-yaml-mandatory-cut.md
@@ -1,0 +1,56 @@
+---
+id: 15
+slug: result-yaml-mandatory-cut
+title: result.yaml mandatory cut for L0 v0.1
+status: accepted
+date: 2026-06-26
+proposition: >
+  Which result.yaml fields are mandatory at L0, and must a failing step carry a
+  human-readable reason?
+options:
+  - id: minimal-core-optional-forensics
+    summary: MUST = evidence, test, status, steps[] (each step id/ordinal/status); failure detail (expected/actual/defect/check) fully optional.
+    chosen: true
+  - id: require-reason-on-failure
+    summary: Require at least one reason field whenever a step is failed/broken.
+    chosen: false
+  - id: require-full-forensics
+    summary: Require expected/actual/defect on non-passing steps.
+    chosen: false
+decision: >
+  result.yaml MUST carry `evidence`, `test`, `status`, and `steps`. Each step
+  MUST carry `id`, `ordinal`, `status`. Everything else — including failure
+  forensics (expected/actual/defect/check) — is optional at L0.
+governs:
+  - design/schemas/L0/result.schema.json#/required
+  - design/schemas/L0/result.schema.json#/$defs/step/required
+feature: [result-model]
+depends_on: [6, 8, 4]
+supersedes: []
+---
+
+## Reasoning
+
+L0 records *that* something happened with a parseable shape; the rich forensics
+that explain *why* are the value of higher levels. The minimal core — format
+version, test id, verdict, and an ordered step list keyed by id/ordinal/status —
+is enough to compute totals, render a pass/fail view, and trace each result to
+its [definition](0004-definition-required-but-opaque.md).
+
+We deliberately did not require a reason on `failed`/`broken` steps. Mandating
+forensics at L0 would burden minimal producers and blur the line between L0
+(minimal) and L1+ (forensic). The example packs that carry `expected`/`actual`/
+`defect`/`check` are richer-than-L0 views; at L0 those fields are available but
+never required.
+
+The [`steps[]` array may be empty](0008-steps-execution-derived.md), and test
+`status` is [authored, not derived](0016-test-status-authored.md).
+
+## Consequences
+
+- The step schema's `required` is exactly `[id, ordinal, status]`.
+- Optional step fields (kind, duration_ms, durable_id, defect, expected, actual,
+  check) and optional test fields (params_hash, external_id, duration_ms,
+  attempts, flaky, tags, requirements) are validated only when present. Keys are
+  [snake_case](0036-snake-case-keys.md); [`attempts` is a per-attempt outcome
+  list](0033-attempts-and-flaky.md), not a scalar count.

--- a/design/decisions/0015-result-yaml-mandatory-cut.md
+++ b/design/decisions/0015-result-yaml-mandatory-cut.md
@@ -22,8 +22,8 @@ decision: >
   MUST carry `id`, `ordinal`, `status`. Everything else — including failure
   forensics (expected/actual/defect/check) — is optional at L0.
 governs:
-  - design/schemas/L0/result.schema.json#/required
-  - design/schemas/L0/result.schema.json#/$defs/step/required
+  - src/schemas/0.1/L0/result.schema.json#/required
+  - src/schemas/0.1/L0/result.schema.json#/$defs/step/required
 feature: [result-model]
 depends_on: [6, 8, 4]
 supersedes: []

--- a/design/decisions/0016-test-status-authored.md
+++ b/design/decisions/0016-test-status-authored.md
@@ -20,7 +20,7 @@ decision: >
   rollup rules. At most, the validator MAY warn if an authored status disagrees
   with the steps; it never overrides.
 governs:
-  - design/schemas/L0/result.schema.json#/properties/status
+  - src/schemas/0.1/L0/result.schema.json#/properties/status
 feature: [result-model]
 depends_on: [8, 6]
 supersedes: []

--- a/design/decisions/0016-test-status-authored.md
+++ b/design/decisions/0016-test-status-authored.md
@@ -1,0 +1,48 @@
+---
+id: 16
+slug: test-status-authored
+title: Test status is authored, not derived
+status: accepted
+date: 2026-06-26
+proposition: >
+  Is a test's verdict computed by evidence-cli from its steps, or authored by the
+  producer?
+options:
+  - id: authored
+    summary: The producer authors the test status; evidence-cli does not compute it.
+    chosen: true
+  - id: derived
+    summary: evidence-cli derives the test status from the worst step.
+    chosen: false
+decision: >
+  The test-level `status` is authored by the producer. evidence-cli does not
+  compute it, because `steps[]` may be empty and the framework may have its own
+  rollup rules. At most, the validator MAY warn if an authored status disagrees
+  with the steps; it never overrides.
+governs:
+  - design/schemas/L0/result.schema.json#/properties/status
+feature: [result-model]
+depends_on: [8, 6]
+supersedes: []
+---
+
+## Reasoning
+
+Deriving the verdict from steps assumes steps exist and that "worst step wins" is
+universal. Neither holds: [steps may be empty](0008-steps-execution-derived.md)
+(a unit test), and frameworks legitimately differ on how step outcomes roll up
+into a test verdict. The producer is the authority on its own result, so it
+authors `status`.
+
+evidence-cli stays a checker, not a judge: it can *warn* on an obvious
+disagreement (e.g. a `passed` test with a `failed` step) as a quality hint, but
+it will not recompute or overwrite the producer's verdict. The run-level
+[`totals`](0011-totals-derived-by-finalize.md), by contrast, *are* derived —
+because they are a pure projection of the authored per-test verdicts, not a
+re-judgment of them.
+
+## Consequences
+
+- The result schema treats `status` as an authored enum value.
+- Any step-vs-test consistency check in the validator is advisory (a warning),
+  not a hard failure.

--- a/design/decisions/0017-commands-validate-and-finalize.md
+++ b/design/decisions/0017-commands-validate-and-finalize.md
@@ -1,0 +1,60 @@
+---
+id: 17
+slug: commands-validate-and-finalize
+title: Stage-one commands — validate and finalize
+status: accepted
+date: 2026-06-26
+proposition: >
+  What is the command surface for the first stage (L0 v0.1)?
+options:
+  - id: validate-and-finalize
+    summary: Two verbs — finalize (derive + seal) and validate (status-gated check).
+    chosen: true
+  - id: validate-finalize-init
+    summary: Add an init scaffolder.
+    chosen: false
+  - id: validate-only
+    summary: Ship validate only; totals computed elsewhere.
+    chosen: false
+decision: >
+  Stage one ships two commands. `evidence finalize <dir>` rolls up totals from
+  every result.yaml, computes and writes each `definition.sha256`, sets
+  `status: finalized`, and seals the pack to a `<name>.evidence` zip.
+  `evidence validate <target> --profile L0` runs the status-gated checks on a
+  directory or a zip.
+governs:
+  - src/
+feature: [validate, finalize]
+depends_on: [11, 5, 3]
+supersedes: []
+---
+
+## Reasoning
+
+The design already implies these two verbs. Because
+[totals are derived by finalize](0011-totals-derived-by-finalize.md) and the
+[definition hash is added at finalize](0005-definition-located-by-path.md),
+`finalize` must exist as an evidence-cli operation — the framework does not
+hand-write those. And the whole point of an open format is a conformance check,
+so `validate` must exist.
+
+`finalize` is the operation that flips the [lifecycle](0007-run-lifecycle.md) to
+`finalized` and produces the sealed [zip](0003-pack-model-and-manifest-anchor.md),
+deriving totals and definition hashes atomically. `validate` is
+[status-gated](0018-status-gated-validation.md): structure-only while running,
+full seal once finalized.
+
+We deferred an `init` scaffolder — nice DX, but not needed to define or check the
+format. It can be added later as purely additive surface. (A third verb,
+[`evidence index`](0034-index-command.md), was subsequently added on the same
+"purely additive surface" grounds to own the optional human renders;
+[`finalize` takes only the live directory](0035-finalize-targets-live-directory.md),
+while `validate` takes a directory or a zip.)
+
+## Consequences
+
+- `src/` implements `finalize` (derive + seal) and `validate` (check).
+- Proposed CLI conventions: exit `0` valid / `1` invalid / `2` usage error;
+  human output by default, `--json` for machine consumption.
+- Both verbs are exposed as library functions so kane-cli can
+  [mount them in-process](0019-runtime-typescript-node.md).

--- a/design/decisions/0018-status-gated-validation.md
+++ b/design/decisions/0018-status-gated-validation.md
@@ -1,0 +1,58 @@
+---
+id: 18
+slug: status-gated-validation
+title: Validation is gated on run status
+status: accepted
+date: 2026-06-26
+proposition: >
+  `ended`, `totals`, and definition hashes only exist after finalize. How should
+  `validate --profile L0` treat a pack depending on its run status?
+options:
+  - id: status-gated
+    summary: running/aborted → structure-only; finalized → full seal with consistency checks.
+    chosen: true
+  - id: finalized-only-input
+    summary: validate always demands the full sealed set; validating a running pack is an error.
+    chosen: false
+decision: >
+  Validation is status-gated. `running` and `aborted` packs get structure-only
+  checks (anchor + identity fields present, each test has result.yaml + a declared
+  `definition.path` whose file EXISTS — only the hash waits for finalize). A
+  `finalized` pack gets the full seal: `ended` and `totals` present, totals
+  consistent with the rolled-up verdicts, and every `definition.{path,sha256}`
+  present with the file existing and hash-matching. The full enumeration of
+  non-schema checks lives in [decision 0031](0031-validator-cross-checks.md).
+governs:
+  - src/
+  - design/schemas/L0/run.schema.json#/allOf
+feature: [validate]
+depends_on: [7, 11, 5]
+supersedes: []
+---
+
+## Reasoning
+
+A [`running`](0007-run-lifecycle.md) pack is mid-flight: `ended`, `totals`, and
+definition *hashes* do not exist yet, so demanding them would produce false
+failures on a perfectly healthy in-progress pack. Gating on status lets the
+validator be useful at every stage — it checks what *should* be true given where
+the run is. Note the definition *file* is held to a different bar than its hash:
+it is the framework's own artifact, authored when the test is defined, so it must
+exist even while `running` — only the [hash](0005-definition-located-by-path.md)
+is deferred to finalize.
+
+`finalized` is the sealed state, so it gets the teeth: totals must agree with the
+per-test [verdicts](0011-totals-derived-by-finalize.md), and the
+[definition](0005-definition-located-by-path.md) files must exist and hash-match.
+`aborted` is treated like `running` (structure-only) — it never got sealed, so we
+do not hold it to the sealed contract.
+
+This is encoded partly in the schema (an `if status==finalized then require
+ended+totals`) and partly in validator logic (totals-vs-verdicts consistency,
+file existence, hash match) that pure JSON Schema cannot express.
+
+## Consequences
+
+- The run schema carries the conditional `ended`/`totals` requirement.
+- The validator implements the cross-file consistency and integrity checks for
+  finalized packs.

--- a/design/decisions/0018-status-gated-validation.md
+++ b/design/decisions/0018-status-gated-validation.md
@@ -24,7 +24,7 @@ decision: >
   non-schema checks lives in [decision 0031](0031-validator-cross-checks.md).
 governs:
   - src/
-  - design/schemas/L0/run.schema.json#/allOf
+  - src/schemas/0.1/L0/run.schema.json#/allOf
 feature: [validate]
 depends_on: [7, 11, 5]
 supersedes: []

--- a/design/decisions/0019-runtime-typescript-node.md
+++ b/design/decisions/0019-runtime-typescript-node.md
@@ -1,0 +1,52 @@
+---
+id: 19
+slug: runtime-typescript-node
+title: Runtime is TypeScript/Node
+status: accepted
+date: 2026-06-26
+proposition: >
+  What language/runtime should evidence-cli be built in, given it will later
+  mount as `kane-cli evidence` (and kane-cli is TypeScript/Node)?
+options:
+  - id: typescript-node
+    summary: TypeScript/Node — mounts in-process into kane-cli, shared types, no subprocess.
+    chosen: true
+  - id: go
+    summary: Go — single static binary; mounts as a spawned binary.
+    chosen: false
+  - id: python
+    summary: Python — matches v16-runner; mounts via subprocess.
+    chosen: false
+decision: >
+  evidence-cli is built in TypeScript/Node. It exposes `validate` and `finalize`
+  as library functions and a thin CLI, so kane-cli mounts it in-process as
+  `kane-cli evidence` with shared types and no subprocess boundary.
+governs:
+  - src/
+  - design/web
+feature: [runtime]
+depends_on: []
+supersedes: []
+---
+
+## Reasoning
+
+The first concrete consumer is kane-cli, which is TypeScript/Node. A TS
+implementation mounts by direct import — `kane-cli evidence` becomes a
+subcommand calling `validate()`/`finalize()` with shared types, no IPC, no
+serialization boundary. That is the cheapest path to the mounting goal and keeps
+the contract types identical on both sides.
+
+Go would give a single static binary (nice for standalone OSS distribution) but
+adds a cross-language boundary to mount into kane-cli. Python matches the runner
+stack but has the same subprocess cost and a heavier runtime dependency. For a
+format library whose primary host is a Node CLI, TS wins.
+
+The [web viewer](0023-viewer-custom-minimal.md) is also a Node/Vite toolchain, so
+one toolchain covers both `src/` and `design/web/`.
+
+## Consequences
+
+- `src/` is TypeScript; the package exports library functions plus a `bin`.
+- Distribution is via npm; a Node runtime is assumed (acceptable for the OSS
+  audience and required by the kane-cli host anyway).

--- a/design/decisions/0020-profile-resolution.md
+++ b/design/decisions/0020-profile-resolution.md
@@ -1,0 +1,50 @@
+---
+id: 20
+slug: profile-resolution
+title: Profile resolution order
+status: accepted
+date: 2026-06-26
+proposition: >
+  A pack is validated against a profile (L0 now; L1–L3 and others later). How is
+  the active profile chosen for a `validate` invocation?
+options:
+  - id: flag-config-default
+    summary: --profile flag, else config defaultProfile, else built-in default.
+    chosen: true
+  - id: flag-only
+    summary: --profile must always be passed.
+    chosen: false
+  - id: config-only
+    summary: Profile comes only from config.
+    chosen: false
+decision: >
+  The active profile resolves as: `--profile` flag → config `defaultProfile` →
+  built-in default (L0). Profiles are additive; adding a new profile never
+  changes the core format.
+governs:
+  - src/
+  - design/contract
+feature: [validate, profiles-config]
+depends_on: [21]
+supersedes: []
+---
+
+## Reasoning
+
+A three-tier resolution gives both ergonomics and explicitness: a caller can be
+explicit per-invocation (`--flag`), a project can set its norm once
+(`config.defaultProfile`), and there is always a sane fallback so the command
+works with zero configuration. This mirrors how most well-behaved CLIs resolve
+settings and avoids forcing a flag on every call.
+
+Profiles are an *additive* axis. L0 is the minimal core; higher and orthogonal
+profiles (L1–L3, browser, mobile, a11y, security) only *add* assertions and
+finding layers — a brand-new profile is purely additive and never rewrites the
+core format. Resolution therefore only selects *which* set of assertions to run,
+never *which* format to expect.
+
+## Consequences
+
+- `validate` reads the flag, then [config](0021-config-location.md), then the
+  built-in default.
+- The profile system is designed so new profiles slot in without touching L0.

--- a/design/decisions/0021-config-location.md
+++ b/design/decisions/0021-config-location.md
@@ -1,0 +1,50 @@
+---
+id: 21
+slug: config-location
+title: Config location — ~/.testmuai/evidence
+status: accepted
+date: 2026-06-26
+proposition: >
+  Where does evidence-cli read its config, balancing the testmuai brand against
+  open-source neutrality?
+options:
+  - id: testmuai-evidence-with-override
+    summary: Default ~/.testmuai/evidence/config.json (brand present, not under kaneai); override via env/flag.
+    chosen: true
+  - id: xdg-neutral
+    summary: Neutral XDG default (~/.config/evidence/config.json).
+    chosen: false
+  - id: kaneai-nested
+    summary: Nest under ~/.testmuai/kaneai/evidence.
+    chosen: false
+decision: >
+  evidence-cli reads `~/.testmuai/evidence/config.json` by default — branded
+  under testmuai, but NOT nested under kaneai (evidence-cli is its own entity,
+  not a kane sub-tool). The location is overridable via the `EVIDENCE_CONFIG`
+  env var or a `--config` flag for fully standalone use. The config holds
+  `defaultProfile` and is extensible to multiple profiles/configs later.
+governs:
+  - src/
+  - design/contract
+feature: [profiles-config]
+depends_on: []
+supersedes: []
+---
+
+## Reasoning
+
+evidence-cli is a standalone, open-sourced entity, so it should not live under
+`kaneai/` — that would imply it is a kane component. But the brand still belongs
+in the path, so `~/.testmuai/evidence/` keeps the testmuai namespace while
+signaling evidence-cli is a peer, not a child, of kane.
+
+For the purely standalone open-source case, the `EVIDENCE_CONFIG` env var and
+`--config` flag let an adopter point anywhere, so the brand default never traps
+a non-testmuai user. The config currently holds only
+[`defaultProfile`](0020-profile-resolution.md) but is structured to grow into
+multiple named configs/profiles.
+
+## Consequences
+
+- Config resolution: `--config` flag → `EVIDENCE_CONFIG` env → `~/.testmuai/evidence/config.json`.
+- A missing config is fine: the built-in default profile (L0) applies.

--- a/design/decisions/0022-decision-record-format.md
+++ b/design/decisions/0022-decision-record-format.md
@@ -1,0 +1,53 @@
+---
+id: 22
+slug: decision-record-format
+title: Decision record format — frontmatter markdown
+status: accepted
+date: 2026-06-26
+proposition: >
+  What is the canonical format of a single decision record — the unit the viewer
+  renders as proposition → decision → reasoning?
+options:
+  - id: frontmatter-md-hybrid
+    summary: One .md per decision with structured YAML frontmatter + a markdown reasoning body.
+    chosen: true
+  - id: pure-prose-adr
+    summary: Classic ADR prose template, no structured frontmatter.
+    chosen: false
+  - id: structured-data-plus-md
+    summary: YAML/JSON records with reasoning in a linked markdown file.
+    chosen: false
+decision: >
+  Each decision is one markdown file with structured YAML frontmatter
+  (`id`, `slug`, `title`, `status`, `date`, `proposition`, `options[]`,
+  `decision`, `governs[]`, `feature[]`, `depends_on[]`, `supersedes[]`) followed
+  by a markdown body holding the reasoning. `feature[]` and `depends_on[]` were
+  added by [decision 0026](0026-decision-graph.md) (traceability) and are part of
+  the canonical shape; field order is `governs` → `feature` → `depends_on` →
+  `supersedes`.
+governs:
+  - design/decisions
+  - design/web
+feature: [decision-system]
+depends_on: [1]
+supersedes: []
+---
+
+## Reasoning
+
+The record must be two things at once: pleasant for a human to write and read in
+a pull request (so, markdown — "MDs are good"), and structured enough for the
+[viewer](0023-viewer-custom-minimal.md) to render proposition→options→decision
+as discrete UI and to link a decision to the schema fields it `governs`. Pure
+prose loses the structure; pure data loses the readability. Frontmatter markdown
+is the hybrid that keeps both — git-diffable, human-writable, machine-renderable.
+
+The `governs` field is what makes the system navigable: it ties each decision to
+the part of the [schema](0024-schemas-single-source-of-truth.md) or repo it
+shaped, so the viewer can cross-link contract ↔ decision in both directions.
+
+## Consequences
+
+- All files in `design/decisions/` follow this frontmatter shape.
+- The viewer parses frontmatter (with js-yaml in the browser, not gray-matter)
+  and renders the body as markdown beneath the structured header.

--- a/design/decisions/0023-viewer-custom-minimal.md
+++ b/design/decisions/0023-viewer-custom-minimal.md
@@ -1,0 +1,55 @@
+---
+id: 23
+slug: viewer-custom-minimal
+title: Viewer is a custom, minimal-but-real local site
+status: accepted
+date: 2026-06-26
+proposition: >
+  How is the local viewer built — and how polished for this first stage — so
+  anyone can browse the structure and the decisions?
+options:
+  - id: custom-minimal-real
+    summary: A lightweight custom Vite/React local site (landing + contract + decisions). Functional first, polish later.
+    chosen: true
+  - id: off-the-shelf-docs
+    summary: Use an off-the-shelf docs generator (Starlight/Docusaurus/MkDocs).
+    chosen: false
+  - id: tiny-markdown-server
+    summary: A minimal markdown folder server.
+    chosen: false
+decision: >
+  A custom, minimal-but-real Vite/React local site under design/web. It has three
+  areas: a loud landing on framework-agnostic combinability, a contract browser
+  (pack layout + rendered schemas), and a decisions log rendering each record as
+  proposition → options → decision → reasoning. Functional first; polish iterates.
+governs:
+  - design/web
+feature: [decision-system]
+depends_on: [1, 22, 24]
+supersedes: []
+---
+
+## Reasoning
+
+This site is the open-source face of the format — it must "speak loudly" that
+evidence works with *any* framework, and it must render the
+[decision records](0022-decision-record-format.md) as real structured cards, not
+just dumped markdown. A custom site gives full control of that landing story and
+of cross-linking decisions to the schema fields they govern.
+
+An off-the-shelf generator (Starlight/Docusaurus) would be faster and bring
+search for free, but cedes control of the loud landing and of the bespoke
+proposition→decision→reasoning rendering. A tiny markdown server is too plain to
+carry the positioning. We accept building a little more now for a viewer that
+matches the ambition; it stays minimal-but-real and can be upgraded later.
+
+It reads its content from the sibling
+[schemas](0024-schemas-single-source-of-truth.md), `contract/`, and
+`decisions/`, so the docs cannot drift from the source of truth.
+
+## Consequences
+
+- `design/web` is a self-contained Vite/React app reading `../decisions`,
+  `../contract`, `../schemas`, and the design overview.
+- Built in [TypeScript/Node](0019-runtime-typescript-node.md), the same
+  toolchain as `src/`.

--- a/design/decisions/0024-schemas-single-source-of-truth.md
+++ b/design/decisions/0024-schemas-single-source-of-truth.md
@@ -1,0 +1,52 @@
+---
+id: 24
+slug: schemas-single-source-of-truth
+title: Schemas are the single source of truth
+status: accepted
+date: 2026-06-26
+proposition: >
+  The validator needs schemas and the docs need to describe the same schemas.
+  Do they share one definition or keep separate copies?
+options:
+  - id: json-schema-shared
+    summary: Author the L0 schemas once as JSON Schema; both the validator and the viewer consume them.
+    chosen: true
+  - id: separate-doc-and-code
+    summary: Maintain a doc description and a code schema independently.
+    chosen: false
+decision: >
+  The L0 schemas under `design/schemas/L0/` are authored once as JSON Schema and
+  are the single source of truth, consumed by BOTH `src/` (validate) AND
+  `design/web` (the contract browser). Documentation cannot drift from the
+  validator because they are the same files.
+governs:
+  - design/schemas/L0
+  - src/
+  - design/web
+feature: [decision-system]
+depends_on: [1]
+supersedes: []
+---
+
+## Reasoning
+
+Drift between "what the docs say" and "what the validator enforces" is the
+classic way a spec loses trust. Eliminating the second copy eliminates the drift:
+there is one artifact, the JSON Schema, and both the tool and the site read it.
+This makes "full visibility" structural rather than a promise — the contract you
+read is literally the contract that is enforced.
+
+JSON Schema is the right shared format: a standard the validator can execute
+directly (via a JSON Schema engine) and that the viewer can walk to render
+human-friendly field tables. It also gives us, for free, the conditional rules
+(e.g. require `ended`+`totals` when `finalized`) the
+[status-gated validator](0018-status-gated-validation.md) needs.
+
+This decision is what gives [0001](0001-decisions-gate-code.md)'s
+"no docs drift from code" its mechanism.
+
+## Consequences
+
+- `src/` loads `design/schemas/L0/*.json` to validate; it does not redefine them.
+- `design/web` renders those same files as the contract's field reference.
+- Schema changes are contract changes and therefore require a decision.

--- a/design/decisions/0024-schemas-single-source-of-truth.md
+++ b/design/decisions/0024-schemas-single-source-of-truth.md
@@ -15,12 +15,12 @@ options:
     summary: Maintain a doc description and a code schema independently.
     chosen: false
 decision: >
-  The L0 schemas under `design/schemas/L0/` are authored once as JSON Schema and
+  The L0 schemas under `src/schemas/0.1/L0/` are authored once as JSON Schema and
   are the single source of truth, consumed by BOTH `src/` (validate) AND
   `design/web` (the contract browser). Documentation cannot drift from the
   validator because they are the same files.
 governs:
-  - design/schemas/L0
+  - src/schemas/0.1/L0
   - src/
   - design/web
 feature: [decision-system]
@@ -29,6 +29,8 @@ supersedes: []
 ---
 
 ## Reasoning
+
+> **Amended by [0038](0038-schemas-canonical-home-in-src.md):** the canonical home is now `src/schemas/<version>/<profile>/` (e.g. `src/schemas/0.1/L0/`), imported directly by the validator. The single-source-of-truth principle below is unchanged — only the location moved.
 
 Drift between "what the docs say" and "what the validator enforces" is the
 classic way a spec loses trust. Eliminating the second copy eliminates the drift:
@@ -47,6 +49,6 @@ This decision is what gives [0001](0001-decisions-gate-code.md)'s
 
 ## Consequences
 
-- `src/` loads `design/schemas/L0/*.json` to validate; it does not redefine them.
+- `src/` loads `src/schemas/0.1/L0/*.json` to validate; it does not redefine them.
 - `design/web` renders those same files as the contract's field reference.
 - Schema changes are contract changes and therefore require a decision.

--- a/design/decisions/0025-repo-structure.md
+++ b/design/decisions/0025-repo-structure.md
@@ -1,0 +1,57 @@
+---
+id: 25
+slug: repo-structure
+title: Repo structure — design/ is the living-spec parent
+status: accepted
+date: 2026-06-26
+proposition: >
+  How is the repo laid out so the living spec is cohesive and rendered, and code
+  is clearly downstream of it?
+options:
+  - id: design-parent
+    summary: design/ is the parent over decisions, contract, schemas, web; src/ and fixtures/ live outside.
+    chosen: true
+  - id: flat
+    summary: Everything flat at repo root.
+    chosen: false
+  - id: docs-separate
+    summary: A separate docs/ tree disconnected from schemas/code.
+    chosen: false
+decision: >
+  `design/` is the parent umbrella for the living spec: `design/decisions/`,
+  `design/contract/`, `design/schemas/`, and `design/web/` (the viewer that
+  renders its siblings). Implementation code `src/` and conformance `fixtures/`
+  live OUTSIDE `design/`.
+governs:
+  - repo
+feature: [decision-system]
+depends_on: [1, 24]
+supersedes: []
+---
+
+## Reasoning
+
+Grouping decisions, contract, schemas, and the viewer under one `design/` parent
+makes the living spec a single, cohesive thing — the viewer renders exactly its
+siblings, and a reader (or the [governance rule](0001-decisions-gate-code.md))
+knows that everything under `design/` is "the spec." Keeping `src/` and
+`fixtures/` outside `design/` keeps the boundary crisp: `design/` is *what and
+why*, `src/` is *how*, and code is visibly downstream of the design it
+implements.
+
+```
+evidence-cli/
+  design/
+    decisions/   ADRs (proposition → options → decision → reasoning)
+    contract/    L0 pack layout, lifecycle, commands, config
+    schemas/L0/  JSON Schema — single source of truth
+    web/         Vite/React viewer rendering the above
+  src/           validate, finalize, profile/config resolution
+  fixtures/      valid-L0/, invalid-L0/
+```
+
+## Consequences
+
+- The viewer reads `../decisions`, `../contract`, `../schemas` from inside `design/web`.
+- `src/` imports schemas from `design/schemas/L0` — the
+  [single source of truth](0024-schemas-single-source-of-truth.md).

--- a/design/decisions/0025-repo-structure.md
+++ b/design/decisions/0025-repo-structure.md
@@ -52,6 +52,7 @@ evidence-cli/
 
 ## Consequences
 
-- The viewer reads `../decisions`, `../contract`, `../schemas` from inside `design/web`.
-- `src/` imports schemas from `design/schemas/L0` — the
+- The viewer reads `../decisions`, `../contract` from inside `design/web`.
+- `src/` imports schemas from `src/schemas/0.1/L0` — the
   [single source of truth](0024-schemas-single-source-of-truth.md).
+- **Amended by [0038](0038-schemas-canonical-home-in-src.md):** the L0 schemas moved out of `design/` to `src/schemas/0.1/L0/` (they are consumed by code, not merely rendered); the rest of this structure stands.

--- a/design/decisions/0026-decision-graph.md
+++ b/design/decisions/0026-decision-graph.md
@@ -1,0 +1,73 @@
+---
+id: 26
+slug: decision-graph
+title: Decisions form a traceability graph
+status: superseded
+date: 2026-06-26
+proposition: >
+  The decisions are a flat list of 25+ files. A reader cannot see which are
+  foundational, which build on others, or how a cluster of decisions produces a
+  capability. How do we make the decision log legible as a structure?
+options:
+  - id: feature-decision-artifact
+    summary: A three-tier traceability graph — Feature (spec area) ← Decisions ← the artifacts they govern — generated from frontmatter, rendered as an interactive node graph.
+    chosen: true
+  - id: feature-decision
+    summary: Two tiers — features and the decisions that shaped them.
+    chosen: false
+  - id: decision-dag-only
+    summary: A plain decision DAG with no first-class feature nodes.
+    chosen: false
+decision: >
+  Decisions form a three-tier traceability graph — Feature ← Decision ← Artifact —
+  generated from frontmatter (`feature`, `depends_on`, `governs`) and rendered as
+  an interactive node graph. SUPERSEDED by decision 0032: the traceability data is
+  kept, but it is now surfaced spec-first (each spec key links to its governing
+  decisions) rather than as a standalone node graph.
+governs:
+  - design/features.yaml
+  - design/decisions
+  - design/web
+feature: [decision-system]
+depends_on: [22, 23]
+supersedes: []
+---
+
+> **Superseded by [decision 0032](0032-spec-centric-navigation.md).** The
+> `feature`/`depends_on`/`governs` traceability frontmatter this decision
+> introduced still stands and is still generated; only its *presentation* changed
+> — from a node graph to spec-first navigation where keys link to their decisions.
+
+## Reasoning
+
+A flat ADR list answers "what did we decide" but not "how does it fit together."
+The connections already exist — every decision names what it `governs` and links
+the decisions it builds on — they are just invisible. Making them a **graph**
+turns the log into something you can navigate: enter from a capability ("why is
+*Validate* the way it is?") and walk back through the decisions that produced it,
+or start at the roots ([governance](0001-decisions-gate-code.md),
+[agnostic](0002-framework-agnostic.md)) and follow the flow outward.
+
+We chose three tiers because the goal is *a decision that leads to a spec or
+feature*: **Feature ← Decision ← Artifact**. Feature nodes are the spec areas
+(defined in [`features.yaml`](../features.yaml)); decision nodes carry a
+`feature` (what they produce) and `depends_on` (the decisions they build on); the
+`governs` field gives the artifact tier (the exact schema field / command / config
+each decision lands in). A decision can feed several features — which is exactly
+why this is a graph, not a tree.
+
+The graph is **generated from frontmatter**, never hand-drawn, so it cannot drift
+from the decisions — the same principle as
+[schemas as the single source of truth](0024-schemas-single-source-of-truth.md).
+It is rendered as an interactive node graph in the
+[viewer](0023-viewer-custom-minimal.md) (a new Map view) with auto-layout and
+click-through to each record.
+
+## Consequences
+
+- Every decision gains two frontmatter fields: `feature: [..]` and `depends_on: [..]`.
+- `design/features.yaml` defines the feature/spec-area nodes and their spec targets.
+- `design/web` gains a Map route (React Flow + dagre) building nodes/edges from
+  decisions + features + governs.
+- Adding a decision means tagging its `feature`/`depends_on` — the graph updates
+  itself.

--- a/design/decisions/0027-evidence-version-and-profiles.md
+++ b/design/decisions/0027-evidence-version-and-profiles.md
@@ -1,0 +1,85 @@
+---
+id: 27
+slug: evidence-version-and-profiles
+title: Evidence version vs profiles — two independent axes
+status: accepted
+date: 2026-06-28
+proposition: >
+  A pack declares `evidence: "0.1"` AND is validated against a profile (L0 now;
+  L1–L3 later). Are the format version and the profile the same axis? What does
+  a new profile mean for the version, and when does the version itself change?
+options:
+  - id: version-spans-profiles
+    summary: >
+      `evidence` is the CONTRACT version and spans the whole profile ladder
+      (L0–L3). Adding a profile is additive and never touches the version; only
+      a BREAKING change to an existing meaning bumps the version.
+    chosen: true
+  - id: version-equals-profile
+    summary: Treat L0/L1/L2/L3 as the version (bump the version when a profile is added).
+    chosen: false
+  - id: forward-tolerant-version
+    summary: Make the validator accept any `evidence` value ≥ its own (loose const).
+    chosen: false
+decision: >
+  `evidence` is the CONTRACT version, not a profile. One contract version spans
+  every profile (L0–L3): a profile only ADDS required assertions on top of what
+  the version already guarantees, so shipping L1 does NOT change `evidence`.
+  The version changes ONLY on a BREAKING change to an existing meaning. Because a
+  validator is pinned to a contract version, `evidence` stays a `const` per
+  schema version: a 0.1 validator MUST reject a 0.2 pack rather than silently
+  mis-read it. Additive = new profile (same version); breaking = version bump,
+  and older packs are never retro-invalidated.
+governs:
+  - design/schemas/L0/run.schema.json#/properties/evidence
+  - design/schemas/L0/result.schema.json#/properties/evidence
+  - design/contract
+feature: [run-model, result-model]
+depends_on: [10, 20]
+supersedes: []
+---
+
+## Reasoning
+
+Two things were being conflated: the *format version* (`evidence: "0.1"`) and the
+*validation profile* (`L0`). The README even wrote "L0 (evidence `0.1`)" as if
+they were one. They are orthogonal:
+
+- **Profile** answers *how much do we require of this pack* — L0 is the minimal
+  core, and [higher/orthogonal profiles are purely additive](0020-profile-resolution.md).
+  A profile never rewrites the core; it only adds assertions.
+- **Version** answers *which contract are these field meanings drawn from*. The
+  whole format is built to [scale by adding](0010-run-yaml-mandatory-cut.md), so
+  the version moves rarely — only when an existing guarantee changes incompatibly.
+
+### Additive vs breaking — the rule that protects the version number
+
+The version is only trustworthy if the boundary is explicit:
+
+| Change | Lever |
+| --- | --- |
+| Add an optional field | Additive — same version |
+| Add a new profile (L1–L3, browser, …) | Additive — same version |
+| Add a field required *only* at a higher profile | Additive — same version |
+| Rename / remove an L0 field | **Breaking — bump version** |
+| Change an L0 field's meaning or an enum value's semantics | **Breaking — bump version** |
+| Tighten an existing L0 requirement | **Breaking — bump version** |
+
+### Why `const`, not a loose range
+
+A version-pinned validator is the point. If a 0.1 validator silently accepted a
+0.2 pack, it would validate field meanings it does not actually understand — the
+exact "spec loses trust" failure [0024](0024-schemas-single-source-of-truth.md)
+guards against. Hard rejection on the version field is the safety mechanism.
+Forward-tolerance lives where it belongs and already exists: unknown *keys* are
+tolerated, and *profiles* are additive — neither requires loosening the version.
+Old packs keep declaring `0.1` and a 0.1 validator keeps validating them forever.
+
+## Consequences
+
+- `evidence` remains `const` in each schema version; its description states it is
+  the contract version spanning profiles, bumped only on a breaking change.
+- Introducing L1 is a new profile and a set of additive assertions — it does not
+  touch `evidence` or any L0 schema.
+- A future `0.2` ships as a sibling schema set; `0.1` packs and the `0.1`
+  validator are unaffected.

--- a/design/decisions/0027-evidence-version-and-profiles.md
+++ b/design/decisions/0027-evidence-version-and-profiles.md
@@ -31,8 +31,8 @@ decision: >
   mis-read it. Additive = new profile (same version); breaking = version bump,
   and older packs are never retro-invalidated.
 governs:
-  - design/schemas/L0/run.schema.json#/properties/evidence
-  - design/schemas/L0/result.schema.json#/properties/evidence
+  - src/schemas/0.1/L0/run.schema.json#/properties/evidence
+  - src/schemas/0.1/L0/result.schema.json#/properties/evidence
   - design/contract
 feature: [run-model, result-model]
 depends_on: [10, 20]

--- a/design/decisions/0028-zip-internal-layout.md
+++ b/design/decisions/0028-zip-internal-layout.md
@@ -1,0 +1,65 @@
+---
+id: 28
+slug: zip-internal-layout
+title: Sealed-zip internal layout — anchor at the archive root
+status: accepted
+date: 2026-06-28
+proposition: >
+  A sealed pack is `<name>.evidence` (a zip). Does the archive wrap a
+  `<name>.evidence/` root folder, or sit flat with `run.yaml` at the zip root?
+  `validate` must read "the top-level run.yaml" from a zip — where is "top"?
+options:
+  - id: flat-anchor-at-root
+    summary: >
+      The zip is flat — `run.yaml` is an entry at the archive root, `tests/…`
+      beside it. The archive entries mirror the directory's contents 1:1, with no
+      wrapping `<name>.evidence/` folder.
+    chosen: true
+  - id: wrapped-root-dir
+    summary: Zip wraps a single `<name>.evidence/` directory; entries are nested under it.
+    chosen: false
+  - id: unspecified
+    summary: Leave it to producers (status quo).
+    chosen: false
+decision: >
+  The sealed zip is FLAT: `run.yaml` is an entry at the archive root and
+  `tests/<id>/…` sit beside it — the archive entries are exactly the *contents*
+  of the `<name>.evidence/` directory, with NO wrapping `<name>.evidence/` folder.
+  "Top-level run.yaml" therefore means an entry named `run.yaml` at the zip root.
+  `validate` reads a directory and a zip identically: the anchor is the root-level
+  `run.yaml` in both.
+governs:
+  - design/contract/01-pack-layout.md
+feature: [pack-format]
+depends_on: [3]
+supersedes: []
+---
+
+## Reasoning
+
+[0003](0003-pack-model-and-manifest-anchor.md) defines the
+[manifest anchor](0003-pack-model-and-manifest-anchor.md) as "a top-level
+`run.yaml`" and says the zip is "the same bytes, just archived." For two
+producers to seal interoperable packs, "top-level" inside a zip has to be
+pinned — `.epub` keeps its anchor flat at the root, most `.zip`s wrap a folder,
+and that ambiguity would split the ecosystem on day one.
+
+We choose **flat**, because it is the literal reading of "the bytes inside are
+identical to the directory": the directory's *contents* become the archive's
+entries. A reader resolves the anchor the same way for both forms — look for
+`run.yaml` at the root — so the [status-gated validator](0018-status-gated-validation.md)
+needs no special-casing, and a `definition.path` that is "relative to the test
+directory" resolves identically whether the pack is live or sealed.
+
+This also keeps [finalize](0035-finalize-targets-live-directory.md) trivial: it
+zips the contents of `<name>.evidence/` into `<name>.evidence` without
+re-rooting anything.
+
+## Consequences
+
+- `evidence finalize` writes a flat zip: archive-root `run.yaml`, `tests/…`
+  beside it, no `<name>.evidence/` wrapper entry.
+- `validate` locates the anchor at the archive root for a zip and at the
+  directory root for a directory — one rule, two containers.
+- The pack `<name>` lives only in the *file* name, never as an internal path
+  segment, consistent with [run_id being the run identity](0010-run-yaml-mandatory-cut.md).

--- a/design/decisions/0029-definition-path-safety.md
+++ b/design/decisions/0029-definition-path-safety.md
@@ -1,0 +1,61 @@
+---
+id: 29
+slug: definition-path-safety
+title: definition.path must be a contained relative path
+status: accepted
+date: 2026-06-28
+proposition: >
+  `definition.path` is authored by the producer and `finalize` reads the file at
+  that path to hash it. What stops a path from escaping the test directory
+  (`../../etc/passwd`) or being absolute (`/etc/...`)?
+options:
+  - id: contained-relative-only
+    summary: >
+      `path` MUST be relative and stay inside its test directory — no leading
+      `/`, no `..` segments, no scheme. Enforced by a schema pattern plus a
+      validator normalization check.
+    chosen: true
+  - id: trust-producer
+    summary: Accept any string; trust the producing framework not to escape.
+    chosen: false
+  - id: flatten-name-only
+    summary: Forbid all subdirectories — `path` must be a bare filename.
+    chosen: false
+decision: >
+  `definition.path` MUST be a relative path contained within its
+  `tests/<id>/` directory: no leading `/`, no `..` segment, no URL scheme. The
+  schema enforces the shape with a `pattern`; `finalize`/`validate` additionally
+  normalize the path and reject anything that resolves outside the test
+  directory. Subdirectories are allowed (a framework may keep `src/login.spec.ts`),
+  bare filenames are the common case.
+governs:
+  - design/schemas/L0/result.schema.json#/properties/definition
+feature: [definition]
+depends_on: [5]
+supersedes: []
+---
+
+## Reasoning
+
+evidence-cli opens and hashes a path it did not choose — the framework
+[pre-declares it](0005-definition-located-by-path.md). A format that other
+frameworks emit, and that CI systems unzip and process, cannot let that path
+reach arbitrary files: `../../../etc/passwd` or an absolute path would turn a
+"hash the definition" step into a file-read primitive over the host. Containment
+is the safe default and costs producers nothing — the definition genuinely lives
+beside its `result.yaml`.
+
+We keep subdirectories legal because some frameworks nest their native artifact
+(`tests/login/src/login.spec.ts`); forbidding all subpaths would be needlessly
+strict. The constraint is only *containment*: the resolved path must stay under
+`tests/<id>/`. JSON Schema's `pattern` catches the obvious shapes (leading slash,
+`..`); the validator does the authoritative normalization check, since a regex
+alone cannot fully reason about path traversal.
+
+## Consequences
+
+- The result schema's `definition.path` gains a `pattern` rejecting absolute
+  paths, `..` segments, and schemes.
+- `finalize` and `validate` normalize `path` and fail if it escapes the test
+  directory — a [validator cross-check](0031-validator-cross-checks.md) that
+  pure schema cannot express.

--- a/design/decisions/0029-definition-path-safety.md
+++ b/design/decisions/0029-definition-path-safety.md
@@ -29,7 +29,7 @@ decision: >
   directory. Subdirectories are allowed (a framework may keep `src/login.spec.ts`),
   bare filenames are the common case.
 governs:
-  - design/schemas/L0/result.schema.json#/properties/definition
+  - src/schemas/0.1/L0/result.schema.json#/properties/definition
 feature: [definition]
 depends_on: [5]
 supersedes: []

--- a/design/decisions/0030-step-ordinal-semantics.md
+++ b/design/decisions/0030-step-ordinal-semantics.md
@@ -27,7 +27,7 @@ decision: >
   sequence. `ordinal` is the step's position in the producer's sequence, not an
   index into the `steps[]` array.
 governs:
-  - design/schemas/L0/result.schema.json#/$defs/step/properties/ordinal
+  - src/schemas/0.1/L0/result.schema.json#/$defs/step/properties/ordinal
 feature: [result-model]
 depends_on: [8]
 supersedes: []

--- a/design/decisions/0030-step-ordinal-semantics.md
+++ b/design/decisions/0030-step-ordinal-semantics.md
@@ -1,0 +1,56 @@
+---
+id: 30
+slug: step-ordinal-semantics
+title: Step ordinal — unique, strictly increasing, gaps allowed
+status: accepted
+date: 2026-06-28
+proposition: >
+  A step has a 1-based `ordinal`. Must ordinals be unique? Contiguous (1,2,3,…)?
+  Match array order? An example shows steps at ordinal 1 and 3 — is that legal?
+options:
+  - id: unique-increasing-gaps-ok
+    summary: >
+      Ordinals are unique and strictly increasing in array order; gaps are
+      allowed (a producer may omit a step it didn't record). Not required to be
+      contiguous.
+    chosen: true
+  - id: contiguous-1-to-n
+    summary: Ordinals must be exactly 1..N with no gaps, matching array length.
+    chosen: false
+  - id: free-integer
+    summary: Any integer ≥ 1, no uniqueness or ordering rule.
+    chosen: false
+decision: >
+  Within a test, step `ordinal` values MUST be unique and strictly increasing in
+  array order. They are NOT required to be contiguous — a producer may leave gaps
+  (e.g. ordinals 1 and 3) when it records only some of a longer conceptual
+  sequence. `ordinal` is the step's position in the producer's sequence, not an
+  index into the `steps[]` array.
+governs:
+  - design/schemas/L0/result.schema.json#/$defs/step/properties/ordinal
+feature: [result-model]
+depends_on: [8]
+supersedes: []
+---
+
+## Reasoning
+
+[Steps are execution-derived and the producer chooses granularity](0008-steps-execution-derived.md);
+it may legitimately record a subset of a longer sequence, which is why the spec's
+own example shows ordinals 1 and 3 with no step 2. So **contiguity cannot be
+required** — it would invalidate honest partial traces.
+
+But two steps claiming the same position, or positions that run backwards
+relative to array order, are meaningless and almost always a producer bug. So we
+require **uniqueness** and **strict increase in array order**: enough to make
+ordinals a real, sortable sequence and to let a reader detect "a step is missing
+here," without forcing producers to renumber when they drop a step. This makes
+`ordinal` carry information the array index cannot (it survives omission), which
+is the only reason to have it alongside array position at all.
+
+## Consequences
+
+- The schema keeps `ordinal` as `integer ≥ 1` and documents "unique, strictly
+  increasing in array order, gaps allowed."
+- Uniqueness and monotonicity are a [validator cross-check](0031-validator-cross-checks.md)
+  (JSON Schema cannot compare array siblings); a violation is an error, a gap is not.

--- a/design/decisions/0031-validator-cross-checks.md
+++ b/design/decisions/0031-validator-cross-checks.md
@@ -1,0 +1,73 @@
+---
+id: 31
+slug: validator-cross-checks
+title: Validator cross-checks beyond JSON Schema
+status: accepted
+date: 2026-06-28
+proposition: >
+  Several L0 rules cannot be expressed in JSON Schema (cross-file equality,
+  sibling comparisons, filesystem facts). They are scattered through prose. What
+  is the explicit, testable list the validator must enforce, and at which status?
+options:
+  - id: enumerate-cross-checks
+    summary: >
+      Name every non-schema check as a first-class part of the contract, each
+      tagged structure-only (any status) or full-seal (finalized).
+    chosen: true
+  - id: leave-in-prose
+    summary: Keep these implied across the various decisions.
+    chosen: false
+decision: >
+  Beyond JSON-Schema shape, `validate` enforces these cross-checks.
+  STRUCTURE-ONLY (every run status): (a) `result.test` equals its `tests/<id>/`
+  directory name; (b) each test dir has a `result.yaml` and a declared
+  `definition.path`, and the file at that path EXISTS; (c) `definition.path` is
+  contained (no escape); (d) step `ordinal`s are unique and strictly increasing.
+  FULL-SEAL (status `finalized`, adds): (e) `ended` ≥ `started`; (f) `totals`
+  equals the rolled-up per-test verdicts AND `totals.tests` equals the sum of the
+  four verdict buckets; (g) every `definition.sha256` is present and hash-matches
+  its file. The step-vs-test status disagreement remains a WARNING, never a
+  failure.
+governs:
+  - src/
+  - design/contract/03-commands.md
+feature: [validate]
+depends_on: [18, 11, 5]
+supersedes: []
+---
+
+## Reasoning
+
+[Status-gated validation](0018-status-gated-validation.md) said full-seal packs
+get "consistency checks … that pure JSON Schema cannot express," but the actual
+list lived implicitly across [totals](0011-totals-derived-by-finalize.md),
+[definition path](0005-definition-located-by-path.md),
+[path safety](0029-definition-path-safety.md), and
+[ordinal](0030-step-ordinal-semantics.md). A conformance format must state these
+as plainly as the schema, or every implementer guesses and the validator drifts
+from the docs — the failure [0024](0024-schemas-single-source-of-truth.md) exists
+to prevent. This decision is the single, testable enumeration.
+
+Two deliberate calls:
+
+- **Definition-file existence is structure-only, not just finalized.** The
+  definition is the framework's own artifact, authored when the test is defined —
+  it should be on disk even mid-run. Only the *hash* waits for
+  [finalize](0035-finalize-targets-live-directory.md). So a `running` pack that
+  points at a missing definition file is already wrong, and we catch it early.
+- **`totals.tests` = sum of the four buckets** is stated explicitly. It falls out
+  of "totals equals the rolled-up verdicts," but naming it makes the invariant
+  testable on its own and documents what `tests` counts (every result, skipped
+  included).
+
+Step-vs-test disagreement stays advisory because the
+[test status is authored](0016-test-status-authored.md), not derived — the
+validator is a checker, not a judge.
+
+## Consequences
+
+- `03-commands.md` lists these checks in its status-gated table.
+- The `fixtures/` corpus should exercise each: dir-name mismatch, missing
+  definition file, escaping path, ordinal collision, `ended` < `started`,
+  totals mismatch, hash mismatch.
+- `src/` implements them on top of the schema pass.

--- a/design/decisions/0032-spec-centric-navigation.md
+++ b/design/decisions/0032-spec-centric-navigation.md
@@ -1,0 +1,70 @@
+---
+id: 32
+slug: spec-centric-navigation
+title: Viewer is spec-centric — keys link to their decisions
+status: accepted
+date: 2026-06-28
+proposition: >
+  The decision graph (0026) renders Feature ← Decision ← Artifact as a node
+  graph. In practice a reader arrives at the *spec* — a pack layout, a `run.yaml`
+  key — and asks "why is this the way it is?". How should the viewer make that
+  the primary motion?
+options:
+  - id: spec-first-click-to-decision
+    summary: >
+      Lead with the spec (contract + schema keys). Every key is selectable and
+      transitions to the decision(s) that `govern` it, built from the same
+      `governs` frontmatter the graph used. The node graph is retired.
+    chosen: true
+  - id: keep-graph
+    summary: Keep the abstract Feature/Decision/Artifact node graph as the map.
+    chosen: false
+  - id: both
+    summary: Keep the graph and add spec-first navigation alongside it.
+    chosen: false
+decision: >
+  The viewer is SPEC-CENTRIC. The primary view renders the spec — pack layout and
+  the L0 schema keys — and every key (and every nested field) is selectable: a
+  selection transitions to the decision(s) that `govern` that key. The mapping is
+  the reverse index of the existing `governs` pointers (e.g.
+  `result.schema.json#/properties/definition`), so it stays generated, never
+  hand-drawn. The abstract node-graph map (0026) is RETIRED in favor of this.
+governs:
+  - design/web
+  - design/features.yaml
+feature: [decision-system]
+depends_on: [22, 24, 26]
+supersedes: [26]
+---
+
+## Reasoning
+
+The traceability data [0026](0026-decision-graph.md) built was right; its
+*entry point* was wrong. A newcomer does not think "show me feature
+`result-model`" — they think "what is this `definition` key, and who decided it
+must be opaque?" A node graph answers the first question; the spec is where the
+second one starts. So we invert the view: the spec is the map, and each key is a
+doorway to its reasoning.
+
+The machinery barely changes — this is why the inversion is cheap. `governs`
+already pins each decision to exact schema pointers and contract pages
+([record format](0022-decision-record-format.md)); we just index it the other
+way (key → decisions instead of decision → keys). The
+[schema-as-source-of-truth](0024-schemas-single-source-of-truth.md) field table
+the viewer already renders becomes the clickable surface, so the mapping cannot
+drift from the schema or the decisions — the same guarantee the graph had.
+
+Retiring the graph (rather than keeping both) keeps one canonical way to navigate
+the reasoning and removes the React-Flow/dagre surface area. Features remain in
+`features.yaml` as the coarse grouping a key's decisions roll up to, but they are
+no longer a separate visual tier.
+
+## Consequences
+
+- `0026` is superseded; the `/map` node-graph route and its
+  React-Flow/dagre/graph code are removed.
+- The viewer builds a `governs` reverse index (key-path → decisions) and makes
+  schema field rows and pack-layout entries selectable, transitioning to the
+  governing decision card(s).
+- A key with no `governs` match is simply inert — the view never breaks on a
+  not-yet-decided field, mirroring the loader's "never crash on absence" rule.

--- a/design/decisions/0033-attempts-and-flaky.md
+++ b/design/decisions/0033-attempts-and-flaky.md
@@ -30,8 +30,8 @@ decision: >
   verdict. `flaky` is optional and means "the attempt statuses disagree" — now a
   real derivation over `attempts`, not a reference to absent data.
 governs:
-  - design/schemas/L0/result.schema.json#/properties/attempts
-  - design/schemas/L0/result.schema.json#/properties/flaky
+  - src/schemas/0.1/L0/result.schema.json#/properties/attempts
+  - src/schemas/0.1/L0/result.schema.json#/properties/flaky
 feature: [result-model]
 depends_on: [6, 15]
 supersedes: []

--- a/design/decisions/0033-attempts-and-flaky.md
+++ b/design/decisions/0033-attempts-and-flaky.md
@@ -1,0 +1,64 @@
+---
+id: 33
+slug: attempts-and-flaky
+title: attempts is a per-attempt outcome list; flaky derives from it
+status: accepted
+date: 2026-06-28
+proposition: >
+  `result.yaml` carries optional `attempts` and `flaky`. `flaky` was described as
+  "true when attempt statuses disagree" — but `attempts` was a bare integer
+  count, so there were no per-attempt statuses to disagree. How are retries
+  modelled?
+options:
+  - id: attempts-array-with-status
+    summary: >
+      `attempts` is an optional array of per-attempt objects, each with a
+      `status` from the verdict enum. Array length is the retry count; `flaky`
+      derives from disagreement among the attempt statuses.
+    chosen: true
+  - id: count-plus-statuses
+    summary: Keep `attempts` an integer and add a parallel `attempt_statuses` array.
+    chosen: false
+  - id: drop-flaky
+    summary: Keep `attempts` an integer count and remove `flaky`.
+    chosen: false
+decision: >
+  `attempts` is an OPTIONAL array of per-attempt outcomes. Each entry is an object
+  with a required `status` drawn from the SAME verdict enum as the test
+  (`passed | failed | broken | skipped`), plus optional detail. The array length
+  is the attempt count; the test-level `status` remains the authoritative final
+  verdict. `flaky` is optional and means "the attempt statuses disagree" — now a
+  real derivation over `attempts`, not a reference to absent data.
+governs:
+  - design/schemas/L0/result.schema.json#/properties/attempts
+  - design/schemas/L0/result.schema.json#/properties/flaky
+feature: [result-model]
+depends_on: [6, 15]
+supersedes: []
+---
+
+## Reasoning
+
+A bare `attempts: 3` count cannot support `flaky = "attempt statuses disagree"` —
+the data it refers to (each attempt's outcome) simply wasn't there. Modelling
+`attempts` as a list of per-attempt outcomes fixes the dangling reference and
+costs nothing for the common single-run case (the field is optional and omitted
+entirely).
+
+Reusing the [verdict enum](0006-verdict-enum.md) for the attempt `status` keeps
+the format small — no second vocabulary for "how did an attempt end" — and makes
+"flaky" precise: a test whose attempts are e.g. `failed` then `passed` is flaky;
+one with `passed`, `passed` is not. The count survives as the array length, so
+nothing is lost by dropping the scalar. The final verdict stays
+[authored at the test level](0016-test-status-authored.md); `attempts` is the
+trail behind it, not a competing verdict.
+
+This stays within the [L0 mandatory cut](0015-result-yaml-mandatory-cut.md):
+`attempts` and `flaky` are both optional, validated only when present.
+
+## Consequences
+
+- `attempts` becomes `array<object>` with each item requiring `status` (verdict
+  enum); other per-attempt fields (e.g. `duration_ms`) are optional.
+- `flaky` stays an optional boolean; its description points at `attempts`.
+- A producer that doesn't retry simply omits `attempts`.

--- a/design/decisions/0034-index-command.md
+++ b/design/decisions/0034-index-command.md
@@ -1,0 +1,67 @@
+---
+id: 34
+slug: index-command
+title: evidence index — autogenerate the human renders
+status: accepted
+date: 2026-06-28
+proposition: >
+  The pack layout allows optional, never-parsed human renders (`summary.md`,
+  `result.md`). Who produces them? `finalize` does not, and hand-authoring them
+  defeats "auto-generated from the load-bearing data."
+options:
+  - id: index-command
+    summary: >
+      A third command, `evidence index`, regenerates the optional human renders
+      (summary.md / result.md) from the load-bearing data. Pure projection;
+      never load-bearing; safe to re-run or delete.
+    chosen: true
+  - id: fold-into-finalize
+    summary: Have `finalize` also write the renders.
+    chosen: false
+  - id: leave-to-producers
+    summary: Say nothing; let each framework write its own renders.
+    chosen: false
+decision: >
+  `evidence index <dir>` autogenerates the optional human renders — the run-level
+  `summary.md` and each `tests/<id>/result.md`/`summary.md` — purely from the
+  load-bearing `run.yaml` + `result.yaml` data. The output is never parsed, never
+  load-bearing, and always reproducible: deleting and re-running `index` changes
+  nothing material. It is kept SEPARATE from `finalize` so sealing stays about
+  derivation+seal and rendering stays optional.
+governs:
+  - src/
+  - design/contract/03-commands.md
+feature: [index]
+depends_on: [17, 3]
+supersedes: []
+---
+
+## Reasoning
+
+[The pack layout](0001-decisions-gate-code.md) promises `summary.md`/`result.md`
+as "auto-generated … never parsed," but [stage-one commands](0017-commands-validate-and-finalize.md)
+only specified `finalize` (derive+seal) and `validate` (check) — nothing
+generated the renders, so the promise had no owner. `evidence index` is that
+owner.
+
+Keeping it a distinct verb (not a `finalize` side-effect) matters: `finalize` is
+the one irreversible, authority-conferring operation
+([it flips the lifecycle and seals](0007-run-lifecycle.md)); rendering is the
+opposite — cosmetic, repeatable, throwaway. Conflating them would make sealing
+depend on a Markdown renderer and tempt readers to treat a render as evidence.
+Separation keeps the [load-bearing set](0015-result-yaml-mandatory-cut.md) and
+the human-friendly set cleanly apart: `index` only ever *reads* load-bearing
+data and *writes* derived prose.
+
+`index` is purely additive surface, exactly the kind of DX command
+[0017 deferred](0017-commands-validate-and-finalize.md) (like `init`) — added now
+because the format already references the renders it produces.
+
+## Consequences
+
+- `src/` gains `index` alongside `validate`/`finalize`, exposed as a library
+  function for the [in-process mount](0019-runtime-typescript-node.md).
+- `index` writes only optional `*.md` renders; it never touches load-bearing
+  YAML and never sets lifecycle or totals.
+- `03-commands.md` documents three commands; the render files stay optional and
+  unparsed in the [pack layout](0003-pack-model-and-manifest-anchor.md).

--- a/design/decisions/0035-finalize-targets-live-directory.md
+++ b/design/decisions/0035-finalize-targets-live-directory.md
@@ -1,0 +1,58 @@
+---
+id: 35
+slug: finalize-targets-live-directory
+title: finalize operates only on the live directory
+status: accepted
+date: 2026-06-28
+proposition: >
+  `finalize` derives totals/hashes, flips to `finalized`, and produces the zip.
+  Does it accept an already-sealed `.evidence` zip as input, or only the live
+  `<name>.evidence/` directory?
+options:
+  - id: directory-only
+    summary: >
+      `finalize` accepts ONLY the live `<name>.evidence/` directory and emits the
+      sealed `<name>.evidence` zip. It refuses an already-sealed zip. `validate`
+      still accepts either form.
+    chosen: true
+  - id: accept-both
+    summary: Let `finalize` accept a zip too (re-finalizing in place).
+    chosen: false
+decision: >
+  `evidence finalize` operates ONLY on the live `<name>.evidence/` directory and
+  produces the sealed `<name>.evidence` zip. It will not finalize an already-
+  sealed zip (that pack is, by definition, already finalized). `validate` is the
+  read-only verb and continues to accept BOTH a directory and a zip; the
+  asymmetry is intentional — only `validate` is container-agnostic.
+governs:
+  - src/
+  - design/contract/03-commands.md
+feature: [finalize]
+depends_on: [17, 3, 7]
+supersedes: []
+---
+
+## Reasoning
+
+`finalize` mutates: it writes `totals`, `definition.sha256`, `ended`, flips
+[`status` to `finalized`](0007-run-lifecycle.md), then seals. Every one of those
+is a property of a *live, in-progress* pack — the `<name>.evidence/` directory.
+An already-sealed [zip](0003-pack-model-and-manifest-anchor.md) is the *output*
+of finalize; feeding it back in has no meaning (it is already finalized) and
+would imply mutating a sealed archive in place. So `finalize`'s input domain is
+exactly the live directory.
+
+[`validate`](0017-commands-validate-and-finalize.md) is different: it only reads,
+and a sealed pack is the most important thing to check, so it must accept the zip
+too. Naming the asymmetry — write-verb takes the directory, read-verb takes
+either — removes the ambiguity in the original "both commands accept either
+form" wording and keeps the [flat-zip layout](0028-zip-internal-layout.md) as a
+pure transport/seal artifact that finalize *creates* and never re-consumes.
+
+## Consequences
+
+- `03-commands.md` no longer says both verbs accept either form: `finalize`
+  takes the live directory; `validate` takes a directory or a zip.
+- `finalize` on a `.evidence` zip is a usage error (exit `2`).
+- Re-rendering after seal is the job of [`index`](0034-index-command.md) on the
+  directory, not a re-`finalize`.

--- a/design/decisions/0036-snake-case-keys.md
+++ b/design/decisions/0036-snake-case-keys.md
@@ -24,8 +24,8 @@ decision: >
   `paramsHash` and `externalId` are renamed to `params_hash` and `external_id`.
   No mixed casing is permitted in any schema, at any profile, going forward.
 governs:
-  - design/schemas/L0/run.schema.json
-  - design/schemas/L0/result.schema.json
+  - src/schemas/0.1/L0/run.schema.json
+  - src/schemas/0.1/L0/result.schema.json
 feature: [run-model, result-model]
 depends_on: [24]
 supersedes: []

--- a/design/decisions/0036-snake-case-keys.md
+++ b/design/decisions/0036-snake-case-keys.md
@@ -1,0 +1,54 @@
+---
+id: 36
+slug: snake-case-keys
+title: All format keys are snake_case
+status: accepted
+date: 2026-06-28
+proposition: >
+  The L0 schemas mixed casing: `run_id`/`duration_ms` (snake) alongside
+  `paramsHash`/`externalId` (camel). What single convention do keys follow?
+options:
+  - id: snake-case-all
+    summary: >
+      Every key in the format is snake_case. Rename `paramsHash`→`params_hash`,
+      `externalId`→`external_id`. No mixed casing anywhere.
+    chosen: true
+  - id: camel-case-all
+    summary: Normalize everything to camelCase instead.
+    chosen: false
+  - id: leave-mixed
+    summary: Accept the mixture.
+    chosen: false
+decision: >
+  Every key in the evidence format is `snake_case`. The camelCase strays
+  `paramsHash` and `externalId` are renamed to `params_hash` and `external_id`.
+  No mixed casing is permitted in any schema, at any profile, going forward.
+governs:
+  - design/schemas/L0/run.schema.json
+  - design/schemas/L0/result.schema.json
+feature: [run-model, result-model]
+depends_on: [24]
+supersedes: []
+---
+
+## Reasoning
+
+An open format that many frameworks emit and many tools parse must be
+predictable: a producer should never have to remember which keys are camel and
+which are snake. The existing core already leaned snake — `run_id`, `started`,
+`ended`, `duration_ms`, `durable_id` — so the two camelCase fields
+(`paramsHash`, `externalId`) were the outliers, and snake is the lower-churn,
+more YAML-idiomatic choice. One convention, applied everywhere, removes a whole
+class of "why didn't my field parse" mistakes.
+
+This is settled now, pre-`0.1`-release, precisely so it never becomes a
+[breaking change](0027-evidence-version-and-profiles.md) later: renaming a key
+after packs exist in the wild would force a version bump. Doing it before any
+producer ships keeps it free.
+
+## Consequences
+
+- `result.schema.json`: `paramsHash` → `params_hash`, `externalId` →
+  `external_id`. Other keys already conform.
+- Any future field, at any profile, is authored in snake_case — enforced in
+  review against the [single source of truth](0024-schemas-single-source-of-truth.md).

--- a/design/decisions/0037-implementation-stack.md
+++ b/design/decisions/0037-implementation-stack.md
@@ -1,0 +1,125 @@
+---
+id: 37
+slug: implementation-stack
+title: Implementation stack & architecture (L0 validate + finalize)
+status: accepted
+date: 2026-06-28
+proposition: >
+  Building `src/` for L0 introduces concrete choices the prior, contract-level
+  decisions do not fix: which JSON-Schema engine, YAML library, zip library, and
+  CLI framework; how TTY vs non-TTY and `--json` output are structured; and how
+  the validator enforces the pinned `evidence` contract version. What single
+  stack and architecture do we commit to, and at what governance weight?
+options:
+  - id: umbrella-stack
+    summary: >
+      One record fixing the whole stack — Ajv(2020-12)+ajv-formats, eemeli `yaml`
+      (Document API, round-trip), `adm-zip`, Commander, a `Reporter` seam for
+      TTY/non-TTY/`--json` — plus the version gate, the pack container, and the
+      module boundaries.
+    chosen: true
+  - id: per-choice-records
+    summary: A separate decision record per library / architecture choice.
+    chosen: false
+  - id: no-record
+    summary: Treat all of it as free implementation detail needing no decision.
+    chosen: false
+decision: >
+  `src/` is built on: Ajv (draft 2020-12) + ajv-formats for the schema pass;
+  eemeli `yaml` via its Document API so `finalize` round-trips producer
+  formatting/comments and only rewrites derived fields; `adm-zip` for the flat
+  seal and for reading a sealed zip (entries are read in memory, never extracted
+  to disk); Commander for the CLI (`bin: evidence`, exit `0` valid / `1` invalid
+  / `2` usage). Output flows through a `Reporter` seam with a TTY-aware
+  `HumanReporter` and a `JsonReporter`, selected by `process.stdout.isTTY` and
+  `--json` and honoring `NO_COLOR`. A pack/container abstraction
+  (`DirectoryContainer` + `ZipContainer`) gives `validate` ONE read path over a
+  directory or a flat zip. A named `CONTRACT_VERSION = "0.1"` plus an up-front
+  version gate enforce the pinned contract version (implementing 0027): a pack
+  whose `evidence` differs is rejected with a dedicated diagnostic and the rest of
+  validation is skipped — reject rather than mis-read. This pass ships `validate`
+  and `finalize`; `index` (0034) is deferred. The whole stack lands as ONE record
+  to honor "no code without a decision" without per-library ceremony.
+governs:
+  - src/
+feature: [runtime, validate, finalize]
+depends_on: [19, 17, 18, 31, 27]
+supersedes: []
+---
+
+## Reasoning
+
+The contract is fully decided; what remained was the mechanical "how." Rather
+than a record per library — which would bury the real architecture under
+boilerplate — or no record at all — which would violate
+[0001](0001-decisions-gate-code.md) the moment `src/` gains a dependency — one
+umbrella record names the stack and the few architectural seams that matter, and
+defers the buildable detail to the implementation spec.
+
+### The picks
+
+- **Ajv (draft 2020-12) + ajv-formats.** The [schemas](0024-schemas-single-source-of-truth.md)
+  use 2020-12 and the `if/then` conditional that
+  [status-gated validation](0018-status-gated-validation.md) leans on; Ajv
+  executes both directly, and `ajv-formats` supplies the `date-time` check the
+  `started`/`ended` fields declare. The schema pass is then a thin wrapper over a
+  standard engine, not a hand-rolled validator.
+- **eemeli `yaml`, Document API.** `finalize` rewrites only derived fields
+  (`totals`, `status`, `ended`, `definition.sha256`). The round-trip Document API
+  preserves producer formatting, key order, and comments, so a finalized file is
+  a minimal, reviewable diff over what the framework authored — the behavior
+  chosen during design. A plain parse/re-emit would reflow producer files
+  needlessly.
+- **`adm-zip`.** The seal is a [flat zip](0028-zip-internal-layout.md) of the
+  directory's contents; `adm-zip` writes that with the least code and reads a
+  sealed pack's entries synchronously. We read entries **in memory** and never
+  extract to disk, and `definition.path` is independently
+  [contained](0029-definition-path-safety.md), so zip-slip is not in play.
+- **Commander.** It matches the sibling `test-harness` CLI, keeping the v16
+  toolchain consistent, and maps cleanly to the proposed `0/1/2` exit convention.
+- **`Reporter` seam.** [0017](0017-commands-validate-and-finalize.md) calls for
+  "human output by default, `--json` for machine consumption." A single seam with
+  a TTY-aware `HumanReporter` (color + `✓/✗/⚠` on a TTY, plain deterministic
+  ASCII off it, `NO_COLOR` honored) and a `JsonReporter` (the exact object the
+  library returns) keeps every command output-agnostic and makes the
+  TTY/non-TTY/`--json` matrix one decision in one place.
+
+### The seams that matter
+
+- **Pack container.** [0028](0028-zip-internal-layout.md) promises "one rule, two
+  containers": the anchor is the root-level `run.yaml` in both a directory and a
+  flat zip. `DirectoryContainer` and `ZipContainer` behind one read interface make
+  that literal — `validate` has no directory-vs-zip branching past construction.
+  `finalize` uses only the directory path and refuses a zip
+  ([0035](0035-finalize-targets-live-directory.md)).
+- **Version gate.** [0027](0027-evidence-version-and-profiles.md) decides the
+  validator is *pinned*: a 0.1 validator must reject a 0.2 pack rather than
+  mis-read it. The schema `const "0.1"` is the backstop, but on its own it emits a
+  cryptic "must equal constant" error. So a named `CONTRACT_VERSION` and an
+  explicit gate run first: a present-but-mismatched `evidence` yields a dedicated
+  `version.unsupported` diagnostic and validation halts (no point checking field
+  meanings drawn from a contract we do not implement). A *missing* `evidence` is a
+  plain required-field error — malformed, not a version mismatch.
+
+### Scope
+
+`validate` and `finalize` are the load-bearing verbs
+([0017](0017-commands-validate-and-finalize.md)); the fixtures corpus already
+exercises `validate`. [`index`](0034-index-command.md) renders are cosmetic and
+their template is unspecified, so it is deferred to a later pass rather than
+guessed at now.
+
+## Consequences
+
+- `package.json` gains runtime deps `ajv`, `ajv-formats`, `yaml`, `adm-zip`,
+  `commander`, and a tiny color lib (`picocolors`); dev deps `typescript`,
+  `vitest`, and the `@types/*` needed.
+- `src/` is laid out as in the implementation spec: `pack/`, `schema/`,
+  `validate/`, `finalize/`, `config.ts`, `yaml.ts`, `report/`, `cli.ts`,
+  `contract.ts`, `index.ts` (the library exports kane-cli mounts in-process per
+  [0019](0019-runtime-typescript-node.md)).
+- The [fixtures](0031-validator-cross-checks.md) corpus drives the `validate`
+  tests; `finalize` gets new fixtures (a `running` pack to seal, a hash-mismatch,
+  an `ended < started`).
+- `index`, color flags beyond `NO_COLOR`, and module-format alignment with
+  kane-cli are out of scope here and tracked for later.

--- a/design/decisions/0038-schemas-canonical-home-in-src.md
+++ b/design/decisions/0038-schemas-canonical-home-in-src.md
@@ -1,0 +1,84 @@
+---
+id: 38
+slug: schemas-canonical-home-in-src
+title: Schemas' canonical home is src/schemas/<version>/<profile>/
+status: accepted
+date: 2026-06-28
+proposition: >
+  0024 made the L0 schemas the single source of truth and placed them under
+  `design/schemas/L0/`; 0025 put all schemas inside the `design/` spec tree. The
+  validator must consume them with no second copy, and 0027 makes `evidence` a
+  version axis that spans the profile ladder. Where do the schemas physically
+  live, and how is that directory organized?
+options:
+  - id: src-version-profile
+    summary: >
+      Move the schemas to `src/schemas/<version>/<profile>/` (e.g.
+      `src/schemas/0.1/L0/`); the validator imports them directly and `design/`
+      (viewer + contract) references that location.
+    chosen: true
+  - id: keep-in-design-copy
+    summary: Leave them under `design/schemas/L0/`; a build step copies them into the package.
+    chosen: false
+  - id: src-flat-profile-only
+    summary: Move to `src/schemas/L0/` with no version segment.
+    chosen: false
+decision: >
+  The schemas' canonical home is `src/schemas/<version>/<profile>/` —
+  `src/schemas/0.1/L0/run.schema.json` and `result.schema.json` today. The
+  validator imports them directly (zero copy), so they remain the SINGLE SOURCE
+  OF TRUTH (0024) now owned by the code; `design/web` and the contract pages
+  reference this location instead of holding their own copy. The tree is
+  VERSION-FIRST because `evidence` spans the profile ladder (0027): one `0.1/`
+  directory holds L0…L3, and a future breaking `0.2/` is a SIBLING tree that
+  leaves `0.1/` untouched. Each schema `$id` gains the version segment
+  (`…/schemas/0.1/L0/run.schema.json`) so two versions never collide in the
+  engine's registry. This AMENDS 0024 (the schemas' location) and 0025 (schemas
+  now live outside `design/`); the single-source-of-truth principle and the rest
+  of the repo structure are unchanged.
+governs:
+  - src/schemas
+  - design/web
+  - design/contract
+feature: [decision-system, runtime]
+depends_on: [24, 25, 27]
+supersedes: []
+---
+
+## Reasoning
+
+[0024](0024-schemas-single-source-of-truth.md)'s goal is that exactly ONE
+artifact is read by both the validator and the viewer — that is what kills doc
+drift. Nothing about that goal requires the artifact to sit under `design/`.
+Putting it where the validator `import`s it with no copy is the strongest
+possible form of "single source": the tool compiles the very bytes the viewer
+renders. The build-step copy was rejected for the opposite reason — it
+reintroduces a generated second file, the exact thing 0024 set out to remove.
+
+The tree is **version-first** because that is the structural expression of
+[0027](0027-evidence-version-and-profiles.md): the `evidence` version spans the
+whole profile ladder, so a version *contains* profiles, never the reverse. A
+profile is never independently versioned, so `0.1/L0`, `0.1/L1`, … all sit under
+one version directory, and 0027's "a future 0.2 ships as a sibling schema set"
+becomes a literal sibling `0.2/` tree. Carrying the version in each `$id` means a
+registry that ever holds both 0.1 and 0.2 schemas (e.g. during a migration
+window) keeps them distinct rather than clobbering one with the other.
+
+This is an **amendment**, not a reversal. [0025](0025-repo-structure.md) keeps
+`design/` as the parent for decisions, contract, and the viewer; only the
+schemas move out, precisely because they are *consumed by code*, not merely
+rendered — the one sibling whose natural owner is `src/`. 0024's principle stands
+verbatim; only the path it points at changes.
+
+## Consequences
+
+- Files move: `design/schemas/L0/run.schema.json` → `src/schemas/0.1/L0/run.schema.json`
+  (and `result.schema.json`); each `$id` gains the `0.1` segment.
+- A tiny `src/schemas/registry.ts` statically imports the JSON and exposes
+  `getSchemas(version, profile)`, so the loader stays version/profile-parameterized
+  yet fully bundleable and type-checked.
+- `design/web`'s schema-load path and the `design/contract`/README path references
+  are updated to the new location.
+- [0024](0024-schemas-single-source-of-truth.md)'s `governs` pointer and
+  [0025](0025-repo-structure.md)'s structure diagram are updated, each with an
+  "Amended by 0038" note, when the move lands.

--- a/design/decisions/0039-finalize-seal-replaces-directory.md
+++ b/design/decisions/0039-finalize-seal-replaces-directory.md
@@ -1,0 +1,71 @@
+---
+id: 39
+slug: finalize-seal-replaces-directory
+title: finalize seals in place — the sealed file replaces the live directory
+status: accepted
+date: 2026-06-28
+proposition: >
+  finalize must emit a file named `<name>.evidence` (0028), but the live pack is a
+  directory with that exact name; a file and a directory of the same name cannot
+  coexist in one parent. 0028/0035 fix the zip's name and internal layout but not
+  WHERE the sealed file lands relative to the identically-named directory. What is
+  the rule?
+options:
+  - id: replace-dir
+    summary: >
+      Build the flat zip in memory, remove the live directory, and write
+      `<name>.evidence` (the file) at the path the directory occupied.
+    chosen: true
+  - id: output-elsewhere
+    summary: Keep the directory; write the seal to cwd or an explicit --output, erroring on collision.
+    chosen: false
+  - id: sibling-distinct-name
+    summary: Keep the directory; write the seal beside it under a non-colliding name.
+    chosen: false
+decision: >
+  `finalize` seals IN PLACE: it builds the flat zip of the directory's contents in
+  memory, removes the live `<name>.evidence/` directory, and writes the sealed
+  `<name>.evidence` FILE at the exact path the directory occupied. The live form
+  becomes the sealed form. The bytes are preserved in the seal and the operation
+  is reversible (unzipping restores the tree); the complete zip buffer is built
+  BEFORE the directory is removed, so a mid-operation failure cannot lose data
+  silently.
+governs:
+  - src/
+  - design/contract/03-commands.md
+feature: [finalize]
+depends_on: [35, 28, 7]
+supersedes: []
+---
+
+## Reasoning
+
+The contract names the sealed artifact `<name>.evidence` and places the live pack
+at `<name>.evidence/` — the same name. A file and a directory cannot share a name
+in one parent, so finalize must choose. Writing the seal elsewhere (cwd,
+`--output`, or a renamed sibling) keeps the directory but breaks the contract's
+promise that the pack's sealed form is exactly `<name>.evidence` at the pack's
+location, and forces every caller to juggle two artifacts and two names.
+
+Sealing in place matches the [lifecycle](0007-run-lifecycle.md): the live
+directory is the in-flight workspace, and finalize is the one irreversible,
+authority-conferring step that turns it into the sealed deliverable. Once sealed,
+the directory is redundant — its bytes live in the [flat zip](0028-zip-internal-layout.md) —
+so replacing it is the natural outcome, the same shape as compressing a folder.
+Because unzipping restores the tree, "destructive" overstates it: nothing is
+lost, the pack only changes form.
+
+The one real risk — losing data if the process dies mid-seal — is bounded by
+building the complete zip buffer in memory and only THEN removing the directory
+and writing the file. The window in which neither the full directory nor the full
+file exists is a single `writeFile` after an in-memory buffer is ready.
+
+## Consequences
+
+- `finalize(dir)` returns `{ totals, sealedPath }` where `sealedPath` is the
+  original directory path, now a file.
+- finalize builds the zip buffer, then `rm -rf`s the directory, then writes the
+  file — never deletes before the buffer is ready.
+- A second `finalize` on the now-sealed file is a usage error (exit `2`,
+  [0035](0035-finalize-targets-live-directory.md)) — it is already finalized.
+- `03-commands.md` gains a line stating the seal replaces the live directory.

--- a/design/features.yaml
+++ b/design/features.yaml
@@ -14,15 +14,15 @@ features:
   - id: definition
     title: Definition handling
     blurb: The opaque, framework-owned definition — referenced and hashed, never parsed.
-    spec: design/schemas/L0/result.schema.json#/properties/definition
+    spec: src/schemas/0.1/L0/result.schema.json#/properties/definition
   - id: result-model
     title: Result model
     blurb: Per-test result.yaml — verdicts, steps, and the L0 mandatory cut.
-    spec: design/schemas/L0/result.schema.json
+    spec: src/schemas/0.1/L0/result.schema.json
   - id: run-model
     title: Run model
     blurb: Run-level run.yaml — lifecycle, totals, metrics, environment.
-    spec: design/schemas/L0/run.schema.json
+    spec: src/schemas/0.1/L0/run.schema.json
   - id: validate
     title: Validate
     blurb: Status-gated conformance checking against a profile.

--- a/design/features.yaml
+++ b/design/features.yaml
@@ -1,0 +1,49 @@
+# Feature / spec-area nodes for the decision traceability.
+#
+# Each feature is a capability of evidence-cli produced by a set of decisions
+# (see each decision's `feature:` frontmatter) and maps to its spec target — the
+# contract page and/or schema/code it ultimately lands in. The viewer is
+# spec-centric (decision 0032, superseding the node graph 0026): a spec key links
+# to its governing decisions via each decision's `governs` pointers; features are
+# the coarse grouping those decisions roll up to.
+features:
+  - id: pack-format
+    title: Pack format & container
+    blurb: The .evidence directory/zip and the run.yaml manifest anchor.
+    spec: design/contract/01-pack-layout.md
+  - id: definition
+    title: Definition handling
+    blurb: The opaque, framework-owned definition — referenced and hashed, never parsed.
+    spec: design/schemas/L0/result.schema.json#/properties/definition
+  - id: result-model
+    title: Result model
+    blurb: Per-test result.yaml — verdicts, steps, and the L0 mandatory cut.
+    spec: design/schemas/L0/result.schema.json
+  - id: run-model
+    title: Run model
+    blurb: Run-level run.yaml — lifecycle, totals, metrics, environment.
+    spec: design/schemas/L0/run.schema.json
+  - id: validate
+    title: Validate
+    blurb: Status-gated conformance checking against a profile.
+    spec: design/contract/03-commands.md
+  - id: finalize
+    title: Finalize
+    blurb: Derive totals + definition hashes, set finalized, seal the live directory to a flat zip.
+    spec: design/contract/03-commands.md
+  - id: index
+    title: Index
+    blurb: Autogenerate the optional human renders (summary.md / result.md) from load-bearing data.
+    spec: design/contract/03-commands.md
+  - id: profiles-config
+    title: Profiles & config
+    blurb: Profile resolution and the testmuai-branded config location.
+    spec: design/contract/03-commands.md
+  - id: runtime
+    title: Runtime & mounting
+    blurb: TypeScript/Node, mounted in-process as `kane-cli evidence`.
+    spec: design/contract/03-commands.md
+  - id: decision-system
+    title: Decision system & viewer
+    blurb: Governance, the ADR format, schemas-as-source-of-truth, and the viewer.
+    spec: design/README.md

--- a/design/schemas/L0/result.schema.json
+++ b/design/schemas/L0/result.schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://evidence-cli.dev/schemas/L0/result.schema.json",
+  "title": "result.yaml (L0)",
+  "description": "THE RESULT for one test inside an .evidence pack (tests/<id>/result.yaml): structured, easy-to-parse per-step outcomes. The test's DEFINITION (the framework's own artifact — kane test.md, a .spec.ts, etc.) lives beside this file and is OPAQUE to evidence-cli; it is referenced by `definition`, never parsed.",
+  "type": "object",
+  "required": ["evidence", "test", "status", "steps"],
+  "properties": {
+    "evidence": {
+      "description": "Evidence CONTRACT version this file conforms to. One contract version spans all profiles (L0–L3); only a breaking change bumps it. Const by design — a validator is pinned to its contract version. See decision 0027.",
+      "const": "0.1"
+    },
+    "test": {
+      "description": "Test identifier. MUST equal the tests/<id>/ directory name — the validator enforces this equality (a cross-check beyond JSON Schema; see decision 0031).",
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "description": "Test verdict, authored by the producer. `failed` = oracle evaluated and the product was wrong. `broken` = oracle could NOT be evaluated (environment/infra/test fault). `skipped` = not executed.",
+      "enum": ["passed", "failed", "broken", "skipped"]
+    },
+    "definition": {
+      "description": "Reference to the opaque definition artifact. The framework pre-declares `path` (its own native filename); `evidence finalize` adds `sha256`. evidence-cli asserts the file at `path` exists and (when sealed) that its hash matches — it never reads the content.",
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "description": "Path to the definition file, relative to and CONTAINED WITHIN this test directory. No leading '/', no '..' segment, no URL scheme — subdirectories are allowed. The pattern below catches the obvious shapes; the validator additionally normalizes the path and rejects any escape (see decisions 0029, 0031).",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(?!/)(?!.*(^|/)\\.\\.(/|$))(?![a-zA-Z][a-zA-Z0-9+.-]*:)[^\\\\]+$"
+        },
+        "sha256": {
+          "description": "Content hash of the definition file. Added by `evidence finalize`. Format: 'sha256:<hex>'.",
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        }
+      },
+      "additionalProperties": true
+    },
+    "steps": {
+      "description": "Ordered per-step outcomes. The framework decides what a 'step' is and its granularity. MAY be empty (a unit/API test may have no sub-steps).",
+      "type": "array",
+      "items": { "$ref": "#/$defs/step" }
+    },
+    "params_hash": {
+      "description": "Optional hash of the parameterization used for this test.",
+      "type": "string"
+    },
+    "external_id": {
+      "description": "Optional open map of links into external systems (e.g. a test-manager URL).",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "duration_ms": { "type": "number", "minimum": 0 },
+    "attempts": {
+      "description": "Optional per-attempt outcomes for a retried test. Each attempt carries a `status` from the verdict enum; the array length is the attempt count. The test-level `status` remains the authoritative final verdict. See decision 0033.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["status"],
+        "properties": {
+          "status": {
+            "description": "Outcome of this attempt — same vocabulary as the test verdict.",
+            "enum": ["passed", "failed", "broken", "skipped"]
+          },
+          "duration_ms": { "type": "number", "minimum": 0 }
+        },
+        "additionalProperties": true
+      }
+    },
+    "flaky": {
+      "description": "Optional. Derived: true when the statuses in `attempts` disagree. See decision 0033.",
+      "type": "boolean"
+    },
+    "tags": { "type": "array", "items": { "type": "string" } },
+    "requirements": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "step": {
+      "type": "object",
+      "required": ["id", "ordinal", "status"],
+      "properties": {
+        "id": {
+          "description": "Stable identifier for the step within this test.",
+          "type": "string",
+          "minLength": 1
+        },
+        "ordinal": {
+          "description": "1-based position in the producer's step sequence (NOT an index into this array). Ordinals MUST be unique and strictly increasing in array order; gaps are allowed when a producer records only some of a longer sequence. Uniqueness/monotonicity is a validator cross-check beyond JSON Schema; see decisions 0030, 0031.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "status": {
+          "description": "Step verdict, same vocabulary as the test verdict.",
+          "enum": ["passed", "failed", "broken", "skipped"]
+        },
+        "kind": {
+          "description": "OPTIONAL producer-defined step kind (open string, e.g. navigate, input, assertion, api, wait). Not required on a step; when present it must be non-empty. evidence-cli never checks the vocabulary. See decision 0009.",
+          "type": "string",
+          "minLength": 1
+        },
+        "duration_ms": { "type": "number", "minimum": 0 },
+        "durable_id": {
+          "description": "Optional stable cross-run identity for the step.",
+          "type": "string"
+        },
+        "defect": {
+          "description": "Optional defect classification for a non-passing step (e.g. Product, Infrastructure, Test).",
+          "type": "string"
+        },
+        "expected": { "type": "string" },
+        "actual": { "type": "string" },
+        "check": {
+          "description": "Optional oracle descriptor.",
+          "type": "object",
+          "properties": {
+            "kind": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/design/schemas/L0/run.schema.json
+++ b/design/schemas/L0/run.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://evidence-cli.dev/schemas/L0/run.schema.json",
+  "title": "run.yaml (L0)",
+  "description": "Run-level manifest for an .evidence pack. Its presence at the top of a pack is what identifies the pack (the manifest anchor). One pack = one run. evidence-cli is framework-agnostic: nothing here is specific to any test framework.",
+  "type": "object",
+  "required": ["evidence", "run_id", "status", "started", "title"],
+  "properties": {
+    "evidence": {
+      "description": "Evidence CONTRACT version this pack conforms to. One contract version spans all profiles (L0–L3); adding a profile is additive and does NOT change it — only a breaking change to an existing meaning bumps the version. A validator is pinned to one contract version, so this is a const: a 0.1 validator rejects other versions rather than silently mis-reading them. See decision 0027.",
+      "const": "0.1"
+    },
+    "run_id": {
+      "description": "Stable identifier for this run.",
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "description": "Lifecycle of the run, NOT a test verdict. While `running`, totals are not yet authoritative; `finalize` seals the pack to `finalized`. `aborted` is a run that ended without sealing.",
+      "enum": ["running", "finalized", "aborted"]
+    },
+    "title": {
+      "description": "Human-readable run title.",
+      "type": "string",
+      "minLength": 1
+    },
+    "started": {
+      "description": "When the run started (RFC3339 / ISO-8601).",
+      "type": "string",
+      "format": "date-time"
+    },
+    "ended": {
+      "description": "When the run ended (RFC3339 / ISO-8601). Required once status is `finalized`.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "totals": {
+      "description": "Verdict roll-up over all tests. DERIVED by `evidence finalize` from every tests/<id>/result.yaml — not hand-authored. Required once status is `finalized`.",
+      "type": "object",
+      "required": ["tests", "passed", "failed", "broken", "skipped"],
+      "additionalProperties": false,
+      "properties": {
+        "tests": { "type": "integer", "minimum": 0 },
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "broken": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "metrics": {
+      "description": "Free-form, framework-defined metrics. Each metric is a typed FACT, never a verdict. The set of metric names and their `type` strings is entirely up to the producing framework.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["value", "type"],
+        "properties": {
+          "value": {
+            "description": "The measured value. A metric is a FACT, never a verdict, so boolean is intentionally excluded — a bare true/false reads as a pass/fail. Emit a flag as a typed string instead. See decision 0012.",
+            "type": ["number", "integer", "string"]
+          },
+          "type": {
+            "description": "Producer-defined type of the metric (open string, e.g. percentage, ratio, count, ms, currency). evidence-cli validates presence only, not vocabulary.",
+            "type": "string",
+            "minLength": 1
+          },
+          "unit": {
+            "description": "Optional display unit.",
+            "type": "string"
+          },
+          "label": {
+            "description": "Optional human label.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "environment": {
+      "description": "Optional provenance/context block — an OPEN map of key:value pairs. The keys below are conventional, none is required, and any additional key:value pairs are allowed. A non-browser framework (unit, API) may legitimately omit model/surfaces — or the whole block — entirely. See decision 0013.",
+      "type": "object",
+      "properties": {
+        "producer": {
+          "description": "The tool that produced this pack.",
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "version": { "type": "string" }
+          },
+          "additionalProperties": true
+        },
+        "model": { "type": "string" },
+        "surfaces": { "type": "array", "items": { "type": "string" } },
+        "ci": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "allOf": [
+    {
+      "description": "Finalized packs are sealed: ended timestamp and the derived totals must be present.",
+      "if": {
+        "properties": { "status": { "const": "finalized" } },
+        "required": ["status"]
+      },
+      "then": {
+        "required": ["ended", "totals"]
+      }
+    }
+  ],
+  "additionalProperties": true
+}

--- a/design/web/.gitignore
+++ b/design/web/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+dist-ssr
+*.local
+.vite

--- a/design/web/index.html
+++ b/design/web/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>evidence-cli · design</title>
+    <meta
+      name="description"
+      content="Evidence for ANY test framework. The living spec for the evidence-cli open format: decisions, contract and L0 schemas."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/design/web/package-lock.json
+++ b/design/web/package-lock.json
@@ -1,0 +1,2386 @@
+{
+  "name": "evidence-design-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "evidence-design-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "dagre": "^0.8.5",
+        "js-yaml": "^4.1.0",
+        "marked": "^12.0.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.2",
+        "reactflow": "^11.11.4"
+      },
+      "devDependencies": {
+        "@types/dagre": "^0.7.52",
+        "@types/js-yaml": "^4.0.9",
+        "@types/react": "^18.3.11",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.2",
+        "typescript": "^5.5.4",
+        "vite": "^5.4.8"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@reactflow/background": {
+      "version": "11.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
+      "integrity": "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/controls": {
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.14.tgz",
+      "integrity": "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/core": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.4.tgz",
+      "integrity": "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/minimap": {
+      "version": "11.7.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.14.tgz",
+      "integrity": "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-resizer": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.14.tgz",
+      "integrity": "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-toolbar": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.14.tgz",
+      "integrity": "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/dagre": {
+      "version": "0.7.54",
+      "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
+      "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.379",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.379.tgz",
+      "integrity": "sha512-v/qV5aV5EUA2pGilzUCq5/eyOloZAqDZBu9UMBIzgPpLlprjSR6zswsWBTv0KpqxLGUAZEwhO95ZCt7srymNVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/reactflow": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
+      "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/background": "11.3.14",
+        "@reactflow/controls": "11.2.14",
+        "@reactflow/core": "11.11.4",
+        "@reactflow/minimap": "11.7.14",
+        "@reactflow/node-resizer": "2.2.14",
+        "@reactflow/node-toolbar": "1.3.14"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/design/web/package.json
+++ b/design/web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "evidence-design-web",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Local documentation viewer for the evidence-cli design spec (decisions, contract, L0 schemas).",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0",
+    "marked": "^12.0.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.2",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.8"
+  }
+}

--- a/design/web/src/App.tsx
+++ b/design/web/src/App.tsx
@@ -1,0 +1,22 @@
+import { Routes, Route, Navigate } from 'react-router-dom'
+import { Nav } from './components/Nav'
+import { Landing } from './components/Landing'
+import { Contract } from './components/Contract'
+import { Decisions } from './components/Decisions'
+
+export default function App() {
+  return (
+    <>
+      <Nav />
+      <Routes>
+        <Route path="/" element={<Landing />} />
+        <Route path="/contract" element={<Contract />} />
+        <Route path="/decisions" element={<Decisions />} />
+        {/* /map (the node graph) was retired in favor of the spec-centric
+            contract view — decision 0032. Redirect any stale link. */}
+        <Route path="/map" element={<Navigate to="/contract" replace />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </>
+  )
+}

--- a/design/web/src/components/Badge.tsx
+++ b/design/web/src/components/Badge.tsx
@@ -1,0 +1,8 @@
+import type { DecisionStatus } from '../types'
+
+const KNOWN = new Set(['accepted', 'proposed', 'superseded'])
+
+export function StatusBadge({ status }: { status: DecisionStatus }) {
+  const cls = KNOWN.has(status) ? status : 'neutral'
+  return <span className={`badge ${cls}`}>{status}</span>
+}

--- a/design/web/src/components/Contract.tsx
+++ b/design/web/src/components/Contract.tsx
@@ -1,0 +1,85 @@
+import type { MouseEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { loadContractPages, loadSchemas, loadDecisions } from '../content/load'
+import { renderMarkdown } from '../content/markdown'
+import { buildGovernsIndex } from '../content/governs'
+import { SchemaTable } from './SchemaTable'
+
+export function Contract() {
+  const pages = loadContractPages()
+  const schemas = loadSchemas()
+  const decisions = loadDecisions()
+  const index = buildGovernsIndex(decisions)
+  const navigate = useNavigate()
+
+  // A decision card rendered inline can link to other decisions by filename
+  // (e.g. 0024-...md). Those are not routes — intercept them and hand off to the
+  // full decisions log, scrolled to the target. Route links (#/decisions) and
+  // external links are left alone.
+  const handleClick = (e: MouseEvent<HTMLDivElement>) => {
+    const anchor = (e.target as HTMLElement).closest('a')
+    if (!anchor) return
+    const href = anchor.getAttribute('href') ?? ''
+    if (/^(https?:|mailto:|#)/i.test(href)) return
+    const m = href.match(/(\d+)[^/]*\.md(?:#.*)?$/i)
+    if (!m) return
+    e.preventDefault()
+    navigate('/decisions', { state: { decision: Number.parseInt(m[1], 10) } })
+  }
+
+  return (
+    <div className="shell" onClick={handleClick}>
+      <div className="page-head">
+        <div className="page-kicker">the spec</div>
+        <h2>What an .evidence pack must contain</h2>
+        <p>
+          The L0 contract is the minimum, framework-neutral shape every pack
+          conforms to. The prose pages are the narrative; the schema tables are
+          generated directly from the JSON Schemas in{' '}
+          <code>design/schemas/L0/</code> — the same files the validator uses.{' '}
+          <b>Every key that a decision shaped is clickable</b>: select it to read
+          the decision(s) behind it, right here.
+        </p>
+      </div>
+
+      {pages.length > 0 && (
+        <section>
+          {pages.map((p) => (
+            <article key={p.file} style={{ marginTop: 28 }}>
+              <div
+                className="prose"
+                dangerouslySetInnerHTML={{ __html: renderMarkdown(p.body) }}
+              />
+            </article>
+          ))}
+        </section>
+      )}
+
+      <div className="section-title">L0 Schemas — click a key for its decisions</div>
+      {schemas.length === 0 ? (
+        <div className="empty">
+          No schemas found in design/schemas/L0/. Add *.json files to populate
+          this section.
+        </div>
+      ) : (
+        schemas.map((doc) => (
+          <SchemaTable doc={doc} index={index} key={doc.file} />
+        ))
+      )}
+
+      {pages.length === 0 && (
+        <p style={{ color: 'var(--faint)', marginTop: 28, fontSize: 13 }}>
+          No prose contract pages yet (design/contract/*.md). The schemas above
+          are the live source of truth.
+        </p>
+      )}
+
+      <div className="footer">
+        <span>generated from design/schemas/L0/*.json + design/decisions/*.md</span>
+        <span>
+          {schemas.length} schema(s) · {decisions.length} decisions
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/design/web/src/components/Contract.tsx
+++ b/design/web/src/components/Contract.tsx
@@ -36,7 +36,7 @@ export function Contract() {
           The L0 contract is the minimum, framework-neutral shape every pack
           conforms to. The prose pages are the narrative; the schema tables are
           generated directly from the JSON Schemas in{' '}
-          <code>design/schemas/L0/</code> — the same files the validator uses.{' '}
+          <code>src/schemas/0.1/L0/</code> — the same files the validator uses.{' '}
           <b>Every key that a decision shaped is clickable</b>: select it to read
           the decision(s) behind it, right here.
         </p>
@@ -58,7 +58,7 @@ export function Contract() {
       <div className="section-title">L0 Schemas — click a key for its decisions</div>
       {schemas.length === 0 ? (
         <div className="empty">
-          No schemas found in design/schemas/L0/. Add *.json files to populate
+          No schemas found in src/schemas/0.1/L0/. Add *.json files to populate
           this section.
         </div>
       ) : (
@@ -75,7 +75,7 @@ export function Contract() {
       )}
 
       <div className="footer">
-        <span>generated from design/schemas/L0/*.json + design/decisions/*.md</span>
+        <span>generated from src/schemas/0.1/L0/*.json + design/decisions/*.md</span>
         <span>
           {schemas.length} schema(s) · {decisions.length} decisions
         </span>

--- a/design/web/src/components/DecisionCard.tsx
+++ b/design/web/src/components/DecisionCard.tsx
@@ -1,0 +1,79 @@
+import { renderMarkdown } from '../content/markdown'
+import { StatusBadge } from './Badge'
+import type { Decision } from '../types'
+
+/**
+ * One decision rendered as proposition → options → decision → reasoning.
+ * Shared by the decisions log and the spec-centric view (a key links here).
+ */
+export function DecisionCard({ decision }: { decision: Decision }) {
+  const d = decision
+  const superseded = d.status === 'superseded'
+  return (
+    <article
+      className={`decision${superseded ? ' superseded' : ''}`}
+      id={`decision-${d.id}`}
+    >
+      <div className="decision-head">
+        <span className="decision-id">#{String(d.id).padStart(4, '0')}</span>
+        <h3>{d.title}</h3>
+        <StatusBadge status={d.status} />
+      </div>
+
+      {d.proposition && (
+        <>
+          <div className="field-label">Proposition</div>
+          <div className="proposition">{d.proposition.trim()}</div>
+        </>
+      )}
+
+      {d.options.length > 0 && (
+        <>
+          <div className="field-label">Options weighed</div>
+          <div className="options">
+            {d.options.map((o) => (
+              <div
+                className={`option ${o.chosen ? 'chosen' : 'notchosen'}`}
+                key={o.id}
+              >
+                <span className="mark">{o.chosen ? '✓' : '·'}</span>
+                <span>
+                  <span className="oid">{o.id}</span>
+                  {o.summary && <span className="osum"> — {o.summary}</span>}
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {d.decision && (
+        <>
+          <div className="field-label">Decision</div>
+          <div className="decision-statement">{d.decision.trim()}</div>
+        </>
+      )}
+
+      {d.governs.length > 0 && (
+        <>
+          <div className="field-label">Governs</div>
+          <div className="governs-row">
+            {d.governs.map((g) => (
+              <span className="govchip" key={g}>
+                {g}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
+
+      {d.body.trim() && (
+        <div
+          className="prose"
+          style={{ marginTop: 18 }}
+          dangerouslySetInnerHTML={{ __html: renderMarkdown(d.body) }}
+        />
+      )}
+    </article>
+  )
+}

--- a/design/web/src/components/Decisions.tsx
+++ b/design/web/src/components/Decisions.tsx
@@ -1,0 +1,64 @@
+import { useEffect, type MouseEvent } from 'react'
+import { useLocation } from 'react-router-dom'
+import { loadDecisions } from '../content/load'
+import { DecisionCard } from './DecisionCard'
+
+export function Decisions() {
+  const decisions = loadDecisions()
+  const location = useLocation()
+
+  // Arriving from a spec key ("click a key → its decision"): scroll to the
+  // decision the spec view handed off via navigation state.
+  useEffect(() => {
+    const target = (location.state as { decision?: number } | null)?.decision
+    if (typeof target !== 'number') return
+    const el = document.getElementById(`decision-${target}`)
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }, [location.state])
+
+  // In-app navigation for links between decision files, e.g.
+  // [single source of truth](0024-...md) -> scroll to that decision card.
+  // Never break: unknown / not-yet-written targets are simply no-ops.
+  const handleClick = (e: MouseEvent<HTMLDivElement>) => {
+    const anchor = (e.target as HTMLElement).closest('a')
+    if (!anchor) return
+    const href = anchor.getAttribute('href') ?? ''
+    if (/^(https?:|mailto:)/i.test(href)) return
+    const m = href.match(/(\d+)[^/]*\.md(?:#.*)?$/i)
+    if (!m) return
+    e.preventDefault()
+    const id = Number.parseInt(m[1], 10)
+    const el = document.getElementById(`decision-${id}`)
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
+  return (
+    <div className="shell">
+      <div className="page-head">
+        <div className="page-kicker">decision log</div>
+        <h2>Why the format is the way it is</h2>
+        <p>
+          Every part of evidence-cli starts as a decision record: the question,
+          the options weighed, the choice, and the reasoning. No code lands
+          without one. Links between decisions navigate in-app.
+        </p>
+      </div>
+
+      <div onClick={handleClick}>
+        {decisions.length === 0 ? (
+          <div className="empty">
+            No decisions found in design/decisions/. Add NNNN-slug.md files to
+            populate this log.
+          </div>
+        ) : (
+          decisions.map((d) => <DecisionCard decision={d} key={d.file} />)
+        )}
+      </div>
+
+      <div className="footer">
+        <span>design/decisions/*.md</span>
+        <span>{decisions.length} decision(s)</span>
+      </div>
+    </div>
+  )
+}

--- a/design/web/src/components/Landing.tsx
+++ b/design/web/src/components/Landing.tsx
@@ -1,0 +1,104 @@
+import { Link } from 'react-router-dom'
+import { loadReadme } from '../content/load'
+import { renderMarkdown } from '../content/markdown'
+
+const L0_FILES = [
+  { k: 'manifest', v: 'run.yaml' },
+  { k: 'per-test', v: 'result.yaml' },
+  { k: 'pack', v: '.evidence' },
+]
+
+const FEATURES = [
+  {
+    tag: 'neutral',
+    title: 'Knows nothing about your framework',
+    body: 'The per-test definition is referenced and hashed, never parsed. kane test.md, a .spec.ts, an API suite — treated identically.',
+  },
+  {
+    tag: 'structured',
+    title: 'The same shape, every time',
+    body: 'A run manifest plus structured per-step results. A CI dashboard, an auditor, or a human can read a pack without knowing what produced it.',
+  },
+  {
+    tag: 'self-hosted',
+    title: 'The repo IS the spec',
+    body: 'Decisions, contract and L0 JSON Schemas live in design/. The validator and these docs render the same files — drift is impossible, not just discouraged.',
+  },
+]
+
+export function Landing() {
+  const readme = loadReadme()
+  return (
+    <div className="shell">
+      <section className="hero">
+        <span className="eyebrow">evidence format · L0</span>
+        <h1>
+          Evidence for <span className="grad">ANY</span> test framework.
+        </h1>
+        <p className="lede">
+          An open, framework-agnostic format for test results. evidence-cli
+          knows nothing about how your tests are written — it records what
+          happened, in one neutral shape, so any tool can read it.
+        </p>
+
+        <div className="install">
+          <span className="prompt">$</span>
+          <span>
+            npm i -g <span className="pkg">evidence-cli</span>
+          </span>
+          <span className="copy">// then `evidence finalize`</span>
+        </div>
+
+        <div className="chips">
+          {L0_FILES.map((c) => (
+            <span className="chip" key={c.v}>
+              <span className="k">{c.k}</span>
+              {c.v}
+            </span>
+          ))}
+        </div>
+
+        <div className="chips" style={{ marginTop: 18 }}>
+          <Link
+            to="/contract"
+            className="chip"
+            style={{ borderColor: 'var(--border-strong)' }}
+          >
+            read the contract →
+          </Link>
+          <Link
+            to="/decisions"
+            className="chip"
+            style={{ borderColor: 'var(--border-strong)' }}
+          >
+            why it is the way it is →
+          </Link>
+        </div>
+      </section>
+
+      <section className="feature-grid">
+        {FEATURES.map((f) => (
+          <div className="feature" key={f.title}>
+            <div className="tag">{f.tag}</div>
+            <h3>{f.title}</h3>
+            <p>{f.body}</p>
+          </div>
+        ))}
+      </section>
+
+      {readme && (
+        <section className="readme-block">
+          <div
+            className="prose"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(readme) }}
+          />
+        </section>
+      )}
+
+      <div className="footer">
+        <span>evidence-cli · design viewer</span>
+        <span>the repo is the spec</span>
+      </div>
+    </div>
+  )
+}

--- a/design/web/src/components/Nav.tsx
+++ b/design/web/src/components/Nav.tsx
@@ -1,0 +1,26 @@
+import { NavLink } from 'react-router-dom'
+
+export function Nav() {
+  return (
+    <header className="topnav">
+      <div className="topnav-inner">
+        <NavLink to="/" className="brand">
+          <span className="dot" />
+          <span>
+            evidence<span style={{ color: 'var(--faint)' }}>-</span>cli
+          </span>
+          <span className="mono" style={{ color: 'var(--faint)' }}>
+            /design
+          </span>
+        </NavLink>
+        <nav className="navlinks">
+          <NavLink to="/" end>
+            home
+          </NavLink>
+          <NavLink to="/contract">spec</NavLink>
+          <NavLink to="/decisions">decisions</NavLink>
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/design/web/src/components/SchemaTable.tsx
+++ b/design/web/src/components/SchemaTable.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react'
+import type { FieldNode, SchemaDoc } from '../types'
+import { buildSchemaFields, rootFlags } from '../content/schema-fields'
+import type { GovernsIndex } from '../content/governs'
+import { DecisionCard } from './DecisionCard'
+
+const ROOT = '__root__'
+
+function reqLabel(node: FieldNode): string {
+  if (node.required.kind === 'yes') return 'required'
+  if (node.required.kind === 'conditional') return 'conditional'
+  return 'optional'
+}
+
+function FieldRow({
+  node,
+  file,
+  index,
+  selected,
+  onToggle,
+}: {
+  node: FieldNode
+  file: string
+  index: GovernsIndex
+  selected: string | null
+  onToggle: (pointer: string) => void
+}) {
+  const enumValues = node.enumValues ?? []
+  const decisions = index.forField(file, node.pointer)
+  const hasDec = decisions.length > 0
+  const open = selected === node.pointer
+
+  return (
+    <div className={`frow${hasDec ? ' has-dec' : ''}${open ? ' open' : ''}`}>
+      <div
+        className="frow-main"
+        role={hasDec ? 'button' : undefined}
+        tabIndex={hasDec ? 0 : undefined}
+        onClick={hasDec ? () => onToggle(node.pointer) : undefined}
+        onKeyDown={
+          hasDec
+            ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  onToggle(node.pointer)
+                }
+              }
+            : undefined
+        }
+      >
+        <span className={`fname${node.name === '«any key»' ? ' anykey' : ''}`}>
+          {node.name}
+        </span>
+        <span className="ftype">{node.typeLabel}</span>
+        <span className={`freq ${node.required.kind}`}>{reqLabel(node)}</span>
+        {hasDec && (
+          <span className="fwhy" title="decisions that shaped this key">
+            {open ? '▾' : '▸'} {decisions.length} decision
+            {decisions.length > 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+
+      {node.description && <div className="fdesc">{node.description}</div>}
+
+      {(node.required.kind === 'conditional' && node.required.note) ||
+      node.constValue !== undefined ||
+      enumValues.length > 0 ||
+      node.constraints.length > 0 ? (
+        <div className="fmeta">
+          {node.required.kind === 'conditional' && node.required.note && (
+            <span className="pill cond">{node.required.note}</span>
+          )}
+          {node.constValue !== undefined && (
+            <span className="pill constv">
+              const: {JSON.stringify(node.constValue)}
+            </span>
+          )}
+          {enumValues.map((v, i) => (
+            <span className="pill enumv" key={i}>
+              {typeof v === 'string' ? v : JSON.stringify(v)}
+            </span>
+          ))}
+          {node.constraints.map((c, i) => (
+            <span className="pill" key={`c-${i}`}>
+              {c}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {open && hasDec && (
+        <div className="field-decisions">
+          {decisions.map((d) => (
+            <DecisionCard decision={d} key={d.file} />
+          ))}
+        </div>
+      )}
+
+      {node.children.length > 0 && (
+        <>
+          {node.childrenLabel && (
+            <div className="fchildren-label">{node.childrenLabel}</div>
+          )}
+          <div className="fchildren">
+            {node.children.map((child, i) => (
+              <FieldRow
+                node={child}
+                file={file}
+                index={index}
+                selected={selected}
+                onToggle={onToggle}
+                key={`${child.name}-${i}`}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+export function SchemaTable({
+  doc,
+  index,
+}: {
+  doc: SchemaDoc
+  index: GovernsIndex
+}) {
+  const fields = buildSchemaFields(doc.schema)
+  const flags = rootFlags(doc.schema)
+  const rootDecisions = index.forSchemaRoot(doc.file)
+  const [selected, setSelected] = useState<string | null>(null)
+  const toggle = (p: string) => setSelected((cur) => (cur === p ? null : p))
+
+  return (
+    <div className="schema-card">
+      <div className="schema-card-head">
+        <div className="file">{doc.file}</div>
+        {doc.schema.title && <h3>{doc.schema.title}</h3>}
+        {doc.schema.description && (
+          <div className="desc">{doc.schema.description}</div>
+        )}
+        {flags.length > 0 && (
+          <div className="schema-flags">
+            {flags.map((f, i) => (
+              <span className="flag" key={i}>
+                {f}
+              </span>
+            ))}
+          </div>
+        )}
+        {rootDecisions.length > 0 && (
+          <div className="schema-root-dec">
+            <button
+              className={`fwhy btn${selected === ROOT ? ' open' : ''}`}
+              onClick={() => toggle(ROOT)}
+            >
+              {selected === ROOT ? '▾' : '▸'} shaped by {rootDecisions.length}{' '}
+              decision{rootDecisions.length > 1 ? 's' : ''}
+            </button>
+            {selected === ROOT && (
+              <div className="field-decisions">
+                {rootDecisions.map((d) => (
+                  <DecisionCard decision={d} key={d.file} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="fields">
+        {fields.length === 0 ? (
+          <div className="empty">No fields defined.</div>
+        ) : (
+          fields.map((node, i) => (
+            <FieldRow
+              node={node}
+              file={doc.file}
+              index={index}
+              selected={selected}
+              onToggle={toggle}
+              key={`${node.name}-${i}`}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/design/web/src/content/frontmatter.ts
+++ b/design/web/src/content/frontmatter.ts
@@ -1,0 +1,31 @@
+import yaml from 'js-yaml'
+
+export interface ParsedMarkdown {
+  data: Record<string, unknown>
+  body: string
+}
+
+const FRONTMATTER_RE = /^﻿?---\s*\r?\n([\s\S]*?)\r?\n---\s*(?:\r?\n)?/
+
+/**
+ * Browser-safe frontmatter splitter. We deliberately avoid gray-matter
+ * (needs Node's Buffer). Split the leading `---...---` block ourselves and
+ * parse it with js-yaml.
+ */
+export function parseFrontmatter(raw: string): ParsedMarkdown {
+  const match = raw.match(FRONTMATTER_RE)
+  if (!match) {
+    return { data: {}, body: raw }
+  }
+  let data: Record<string, unknown> = {}
+  try {
+    const parsed = yaml.load(match[1])
+    if (parsed && typeof parsed === 'object') {
+      data = parsed as Record<string, unknown>
+    }
+  } catch {
+    data = {}
+  }
+  const body = raw.slice(match[0].length)
+  return { data, body }
+}

--- a/design/web/src/content/governs.ts
+++ b/design/web/src/content/governs.ts
@@ -13,12 +13,12 @@ function basename(path: string): string {
 
 /**
  * Normalize a `governs` entry into lookup tokens.
- *   design/schemas/L0/run.schema.json#/properties/totals
+ *   src/schemas/0.1/L0/run.schema.json#/properties/totals
  *     -> "run.schema.json#/properties/totals"
  *   design/contract/03-commands.md
  *     -> "design/contract/03-commands.md"
- *   design/schemas/L0/run.schema.json
- *     -> "design/schemas/L0/run.schema.json" AND "run.schema.json"
+ *   src/schemas/0.1/L0/run.schema.json
+ *     -> "src/schemas/0.1/L0/run.schema.json" AND "run.schema.json"
  */
 function tokensFor(governs: string): string[] {
   const hash = governs.indexOf('#')

--- a/design/web/src/content/governs.ts
+++ b/design/web/src/content/governs.ts
@@ -1,0 +1,78 @@
+import type { Decision } from '../types'
+
+// ---------------------------------------------------------------------------
+// Reverse index of the decisions' `governs` pointers, so the spec view can ask
+// "which decisions shaped THIS key?" — the inverse of the decision → artifact
+// link. This is what makes the viewer spec-centric (decision 0032): the same
+// `governs` data the retired node graph used, indexed the other way.
+// ---------------------------------------------------------------------------
+
+function basename(path: string): string {
+  return path.split('/').pop() ?? path
+}
+
+/**
+ * Normalize a `governs` entry into lookup tokens.
+ *   design/schemas/L0/run.schema.json#/properties/totals
+ *     -> "run.schema.json#/properties/totals"
+ *   design/contract/03-commands.md
+ *     -> "design/contract/03-commands.md"
+ *   design/schemas/L0/run.schema.json
+ *     -> "design/schemas/L0/run.schema.json" AND "run.schema.json"
+ */
+function tokensFor(governs: string): string[] {
+  const hash = governs.indexOf('#')
+  if (hash >= 0) {
+    const file = governs.slice(0, hash)
+    const pointer = governs.slice(hash + 1) // keeps leading '/'
+    return [`${basename(file)}#${pointer}`]
+  }
+  const toks = [governs]
+  if (governs.endsWith('.schema.json')) toks.push(basename(governs))
+  return toks
+}
+
+export interface GovernsIndex {
+  /** decisions governing a schema field, keyed `<file>#<pointer>` */
+  forField(schemaFile: string, pointer: string): Decision[]
+  /** decisions governing a whole schema file (root / #/required / #/allOf) */
+  forSchemaRoot(schemaFile: string): Decision[]
+  /** decisions governing an artifact/area path or token */
+  forToken(token: string): Decision[]
+}
+
+export function buildGovernsIndex(decisions: Decision[]): GovernsIndex {
+  const map = new Map<string, Decision[]>()
+  const add = (key: string, d: Decision) => {
+    const arr = map.get(key)
+    if (arr) {
+      if (!arr.includes(d)) arr.push(d)
+    } else map.set(key, [d])
+  }
+  for (const d of decisions) {
+    for (const g of d.governs) {
+      for (const tok of tokensFor(g)) add(tok, d)
+    }
+  }
+  const get = (key: string): Decision[] => {
+    const arr = map.get(key)
+    return arr ? [...arr].sort((a, b) => a.id - b.id) : []
+  }
+  return {
+    forField: (file, pointer) => get(`${file}#${pointer}`),
+    forSchemaRoot: (file) => {
+      const seen = new Set<number>()
+      const out: Decision[] = []
+      for (const key of [file, `${file}#/required`, `${file}#/allOf`]) {
+        for (const d of get(key)) {
+          if (!seen.has(d.id)) {
+            seen.add(d.id)
+            out.push(d)
+          }
+        }
+      }
+      return out.sort((a, b) => a.id - b.id)
+    },
+    forToken: (token) => get(token),
+  }
+}

--- a/design/web/src/content/load.ts
+++ b/design/web/src/content/load.ts
@@ -12,10 +12,10 @@ import type {
 // ---------------------------------------------------------------------------
 // Sibling content is loaded at build/dev time via import.meta.glob.
 // Paths are relative to THIS module (design/web/src/content/load.ts):
-//   ../../../decisions  -> design/decisions
-//   ../../../contract   -> design/contract
-//   ../../../schemas/L0 -> design/schemas/L0
-//   ../../../README.md  -> design/README.md
+//   ../../../decisions          -> design/decisions
+//   ../../../contract           -> design/contract
+//   ../../../../src/schemas/0.1/L0 -> src/schemas/0.1/L0 (canonical home, decision 0038)
+//   ../../../README.md          -> design/README.md
 // Every glob may return 0..N entries — the app must never crash on absence.
 // ---------------------------------------------------------------------------
 
@@ -132,7 +132,7 @@ export function loadContractPages(): ContractPage[] {
 
 // --- Schemas ---------------------------------------------------------------
 
-const schemaFiles = import.meta.glob('../../../schemas/L0/*.json', {
+const schemaFiles = import.meta.glob('../../../../src/schemas/0.1/L0/*.json', {
   eager: true,
   import: 'default',
 }) as Record<string, JSONSchema>

--- a/design/web/src/content/load.ts
+++ b/design/web/src/content/load.ts
@@ -1,0 +1,197 @@
+import yaml from 'js-yaml'
+import { parseFrontmatter } from './frontmatter'
+import type {
+  Decision,
+  DecisionOption,
+  ContractPage,
+  SchemaDoc,
+  JSONSchema,
+  Feature,
+} from '../types'
+
+// ---------------------------------------------------------------------------
+// Sibling content is loaded at build/dev time via import.meta.glob.
+// Paths are relative to THIS module (design/web/src/content/load.ts):
+//   ../../../decisions  -> design/decisions
+//   ../../../contract   -> design/contract
+//   ../../../schemas/L0 -> design/schemas/L0
+//   ../../../README.md  -> design/README.md
+// Every glob may return 0..N entries — the app must never crash on absence.
+// ---------------------------------------------------------------------------
+
+function basename(path: string): string {
+  return path.split('/').pop() ?? path
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined
+}
+
+function asStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return []
+  return v.filter((x): x is string => typeof x === 'string')
+}
+
+function asNumberArray(v: unknown): number[] {
+  if (!Array.isArray(v)) return []
+  return v
+    .map((x) => (typeof x === 'number' ? x : Number(x)))
+    .filter((x) => Number.isFinite(x))
+}
+
+// --- Decisions -------------------------------------------------------------
+
+const decisionFiles = import.meta.glob('../../../decisions/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+function parseOptions(raw: unknown): DecisionOption[] {
+  if (!Array.isArray(raw)) return []
+  return raw.map((o, i) => {
+    const obj = (o && typeof o === 'object' ? o : {}) as Record<string, unknown>
+    return {
+      id: asString(obj.id) ?? `option-${i + 1}`,
+      summary: asString(obj.summary) ?? '',
+      chosen: obj.chosen === true,
+    }
+  })
+}
+
+export function loadDecisions(): Decision[] {
+  const decisions: Decision[] = Object.entries(decisionFiles).map(
+    ([path, raw]) => {
+      const file = basename(path)
+      const { data, body } = parseFrontmatter(raw)
+      const numericFromName = Number.parseInt(file, 10)
+      const id =
+        typeof data.id === 'number'
+          ? data.id
+          : Number.isFinite(Number(data.id))
+            ? Number(data.id)
+            : Number.isFinite(numericFromName)
+              ? numericFromName
+              : 0
+      const supersedes = Array.isArray(data.supersedes)
+        ? (data.supersedes as (string | number)[])
+        : []
+      return {
+        id,
+        slug: asString(data.slug) ?? file.replace(/\.md$/, ''),
+        title: asString(data.title) ?? file,
+        status: asString(data.status) ?? 'proposed',
+        date: asString(data.date),
+        proposition: asString(data.proposition),
+        options: parseOptions(data.options),
+        decision: asString(data.decision),
+        governs: asStringArray(data.governs),
+        supersedes,
+        feature: asStringArray(data.feature),
+        dependsOn: asNumberArray(data.depends_on),
+        body,
+        file,
+      }
+    },
+  )
+  decisions.sort((a, b) => a.id - b.id)
+  return decisions
+}
+
+// --- Contract pages --------------------------------------------------------
+
+const contractFiles = import.meta.glob('../../../contract/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+export function loadContractPages(): ContractPage[] {
+  const pages: ContractPage[] = Object.entries(contractFiles).map(
+    ([path, raw]) => {
+      const file = basename(path)
+      const { data, body } = parseFrontmatter(raw)
+      const order =
+        typeof data.order === 'number'
+          ? data.order
+          : Number.isFinite(Number(data.order))
+            ? Number(data.order)
+            : 1000
+      return {
+        title: asString(data.title) ?? file.replace(/\.md$/, ''),
+        order,
+        body,
+        file,
+        slug: file.replace(/\.md$/, ''),
+      }
+    },
+  )
+  pages.sort((a, b) => a.order - b.order || a.title.localeCompare(b.title))
+  return pages
+}
+
+// --- Schemas ---------------------------------------------------------------
+
+const schemaFiles = import.meta.glob('../../../schemas/L0/*.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, JSONSchema>
+
+export function loadSchemas(): SchemaDoc[] {
+  const docs: SchemaDoc[] = Object.entries(schemaFiles).map(
+    ([path, schema]) => ({
+      file: basename(path),
+      schema,
+    }),
+  )
+  docs.sort((a, b) => a.file.localeCompare(b.file))
+  return docs
+}
+
+// --- README (landing narrative) -------------------------------------------
+
+const readmeFiles = import.meta.glob('../../../README.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+export function loadReadme(): string | null {
+  const first = Object.values(readmeFiles)[0]
+  const trimmed = (first ?? '').trim()
+  // A near-empty README (just a title) is not a useful narrative.
+  if (trimmed.length < 24) return null
+  return first ?? null
+}
+
+// --- Features (decision-graph spec-area nodes) -----------------------------
+
+const featureFiles = import.meta.glob('../../../features.yaml', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+export function loadFeatures(): Feature[] {
+  const raw = Object.values(featureFiles)[0]
+  if (!raw) return []
+  let parsed: unknown
+  try {
+    parsed = yaml.load(raw)
+  } catch {
+    return []
+  }
+  const list = (parsed as { features?: unknown })?.features
+  if (!Array.isArray(list)) return []
+  return list
+    .map((f) => {
+      const obj = (f && typeof f === 'object' ? f : {}) as Record<string, unknown>
+      return {
+        id: asString(obj.id) ?? '',
+        title: asString(obj.title) ?? asString(obj.id) ?? '',
+        blurb: asString(obj.blurb),
+        spec: asString(obj.spec),
+      }
+    })
+    .filter((f) => f.id.length > 0)
+}

--- a/design/web/src/content/markdown.ts
+++ b/design/web/src/content/markdown.ts
@@ -1,0 +1,12 @@
+import { Marked } from 'marked'
+
+// First-party content; a fresh Marked instance keeps config local & predictable.
+const marked = new Marked({
+  gfm: true,
+  breaks: false,
+})
+
+export function renderMarkdown(md: string): string {
+  if (!md) return ''
+  return marked.parse(md, { async: false }) as string
+}

--- a/design/web/src/content/schema-fields.ts
+++ b/design/web/src/content/schema-fields.ts
@@ -1,0 +1,223 @@
+import type { FieldNode, JSONSchema, RequiredInfo } from '../types'
+
+// ---------------------------------------------------------------------------
+// Turn a JSON Schema (draft 2020-12) into a recursive tree of FieldNodes that
+// the UI can render as a human-friendly field table:
+//   name · type · required(yes/no/conditional) · description · constraints
+// Handles: nested objects, array items, $ref (#/$defs/...), enum/const,
+// additionalProperties-as-schema (open maps like `metrics`), and allOf if/then
+// conditional requirements (e.g. "required when status = finalized").
+// ---------------------------------------------------------------------------
+
+function isSchema(v: unknown): v is JSONSchema {
+  return !!v && typeof v === 'object' && !Array.isArray(v)
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined
+}
+
+function formatValue(v: unknown): string {
+  if (typeof v === 'string') return `"${v}"`
+  return JSON.stringify(v)
+}
+
+function resolveRef(root: JSONSchema, ref: string): JSONSchema | undefined {
+  if (!ref.startsWith('#/')) return undefined
+  const parts = ref.slice(2).split('/')
+  let cur: unknown = root
+  for (const p of parts) {
+    if (cur && typeof cur === 'object' && p in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[p]
+    } else {
+      return undefined
+    }
+  }
+  return isSchema(cur) ? cur : undefined
+}
+
+function jsonType(schema: JSONSchema): string | undefined {
+  const t = schema.type
+  if (Array.isArray(t)) return t.join(' | ')
+  return typeof t === 'string' ? t : undefined
+}
+
+function typeLabelFor(
+  schema: JSONSchema,
+  refName: string | undefined,
+): string {
+  if (refName) return `${jsonType(schema) ?? 'object'} · ${refName}`
+  if ('const' in schema) return 'const'
+  if (Array.isArray(schema.enum)) return 'enum'
+  const t = schema.type
+  if (Array.isArray(t)) return t.join(' | ')
+  if (t === 'array') {
+    const item = schema.items
+    if (isSchema(item)) {
+      if (typeof item.$ref === 'string') return `array<${item.$ref.split('/').pop()}>`
+      return `array<${jsonType(item) ?? 'any'}>`
+    }
+    return 'array'
+  }
+  if (t === 'object') {
+    if (
+      !schema.properties &&
+      schema.additionalProperties &&
+      typeof schema.additionalProperties === 'object'
+    ) {
+      return 'object · open map'
+    }
+    return 'object'
+  }
+  return typeof t === 'string' ? t : 'any'
+}
+
+function constraintsFor(schema: JSONSchema): string[] {
+  const c: string[] = []
+  if (typeof schema.minLength === 'number') c.push(`minLength ${schema.minLength}`)
+  if (typeof schema.maxLength === 'number') c.push(`maxLength ${schema.maxLength}`)
+  if (typeof schema.minimum === 'number') c.push(`min ${schema.minimum}`)
+  if (typeof schema.maximum === 'number') c.push(`max ${schema.maximum}`)
+  if (typeof schema.format === 'string') c.push(`format: ${schema.format}`)
+  if (typeof schema.pattern === 'string') c.push(`pattern: ${schema.pattern}`)
+  return c
+}
+
+function describeCondition(ifS: JSONSchema): string {
+  const parts: string[] = []
+  const props = ifS.properties ?? {}
+  for (const [k, v] of Object.entries(props)) {
+    if (!isSchema(v)) {
+      parts.push(k)
+      continue
+    }
+    if ('const' in v) parts.push(`${k} = ${formatValue(v.const)}`)
+    else if (Array.isArray(v.enum))
+      parts.push(`${k} ∈ {${v.enum.map(formatValue).join(', ')}}`)
+    else parts.push(k)
+  }
+  return parts.join(' and ')
+}
+
+/** Map of field name -> human note, derived from this schema's allOf if/then. */
+function extractConditionals(schema: JSONSchema): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const entry of schema.allOf ?? []) {
+    if (!isSchema(entry)) continue
+    const ifS = (entry as Record<string, unknown>).if
+    const thenS = (entry as Record<string, unknown>).then
+    if (!isSchema(ifS) || !isSchema(thenS)) continue
+    const cond = describeCondition(ifS)
+    for (const f of thenS.required ?? []) {
+      const note = cond ? `required when ${cond}` : 'conditionally required'
+      map.set(f, map.has(f) ? `${map.get(f)}; ${note}` : note)
+    }
+  }
+  return map
+}
+
+function objectChildren(
+  schema: JSONSchema,
+  root: JSONSchema,
+  base: string,
+): FieldNode[] {
+  const required = new Set(schema.required ?? [])
+  const conds = extractConditionals(schema)
+  const out: FieldNode[] = []
+
+  for (const [name, sub] of Object.entries(schema.properties ?? {})) {
+    if (!isSchema(sub)) continue
+    const reqInfo: RequiredInfo = conds.has(name)
+      ? { kind: 'conditional', note: conds.get(name) }
+      : { kind: required.has(name) ? 'yes' : 'no' }
+    out.push(buildNode(name, sub, root, reqInfo, `${base}/properties/${name}`))
+  }
+
+  // additionalProperties as a schema => an open map of typed values.
+  const ap = schema.additionalProperties
+  if (isSchema(ap)) {
+    out.push(
+      buildNode('«any key»', ap, root, { kind: 'no' }, `${base}/additionalProperties`),
+    )
+  }
+
+  return out
+}
+
+function buildNode(
+  name: string,
+  sub: JSONSchema,
+  root: JSONSchema,
+  required: RequiredInfo,
+  pointer: string,
+): FieldNode {
+  let schema = sub
+  let refName: string | undefined
+  let refTarget: string | undefined
+  if (typeof sub.$ref === 'string') {
+    refName = sub.$ref.split('/').pop()
+    refTarget = sub.$ref.startsWith('#') ? sub.$ref.slice(1) : undefined
+    const resolved = resolveRef(root, sub.$ref)
+    if (resolved) {
+      schema = {
+        ...resolved,
+        ...(sub.description ? { description: sub.description } : {}),
+      }
+    }
+  }
+
+  const node: FieldNode = {
+    name,
+    typeLabel: typeLabelFor(schema, refName),
+    required,
+    description: asString(schema.description),
+    enumValues: Array.isArray(schema.enum) ? schema.enum : undefined,
+    constValue: 'const' in schema ? schema.const : undefined,
+    constraints: constraintsFor(schema),
+    children: [],
+    pointer,
+  }
+
+  // The schema location whose `properties` define this node's children: the
+  // $ref target if this node is a reference, else the node's own pointer. This
+  // is what keeps a step field's pointer at /$defs/step/properties/… so it
+  // matches the decisions' `governs` entries.
+  const defBase = refTarget ?? pointer
+
+  const isObject =
+    schema.type === 'object' || (!schema.type && !!schema.properties)
+
+  if (isObject) {
+    node.children = objectChildren(schema, root, defBase)
+    if (node.children.length) node.childrenLabel = 'fields'
+    if (schema.additionalProperties === false)
+      node.constraints.push('closed: no extra keys')
+    else if (schema.additionalProperties === true)
+      node.constraints.push('open: extra keys allowed')
+  } else if (schema.type === 'array' && isSchema(schema.items)) {
+    const item = schema.items
+    const itemPointer =
+      typeof item.$ref === 'string' && item.$ref.startsWith('#')
+        ? item.$ref.slice(1)
+        : `${pointer}/items`
+    const itemNode = buildNode('items', item, root, { kind: 'no' }, itemPointer)
+    node.children = itemNode.children
+    if (node.children.length) node.childrenLabel = 'each item'
+  }
+
+  return node
+}
+
+export function buildSchemaFields(root: JSONSchema): FieldNode[] {
+  return objectChildren(root, root, '')
+}
+
+/** Top-of-card caption flags worth surfacing (e.g. open vs closed root). */
+export function rootFlags(root: JSONSchema): string[] {
+  const flags: string[] = []
+  if (root.additionalProperties === true) flags.push('open: extra keys allowed')
+  else if (root.additionalProperties === false) flags.push('closed: no extra keys')
+  if ((root.required ?? []).length)
+    flags.push(`required: ${(root.required ?? []).join(', ')}`)
+  return flags
+}

--- a/design/web/src/main.tsx
+++ b/design/web/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { HashRouter } from 'react-router-dom'
+import App from './App'
+import './styles.css'
+
+const container = document.getElementById('root')
+if (!container) throw new Error('Root element #root not found')
+
+createRoot(container).render(
+  <StrictMode>
+    <HashRouter>
+      <App />
+    </HashRouter>
+  </StrictMode>,
+)

--- a/design/web/src/styles.css
+++ b/design/web/src/styles.css
@@ -1,0 +1,718 @@
+:root {
+  --bg: #0b0910;
+  --bg-2: #110d1c;
+  --panel: rgba(255, 255, 255, 0.025);
+  --panel-2: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.09);
+  --border-strong: rgba(255, 255, 255, 0.16);
+  --text: #ece8f7;
+  --muted: #9a93b6;
+  --faint: #6f6889;
+
+  --brand: #8b5cf6;
+  --brand-2: #6366f1;
+  --brand-3: #a855f7;
+  --warm: #f59e0b;
+  --warm-2: #fb7185;
+
+  --green: #34d399;
+  --teal: #2dd4bf;
+  --amber: #fbbf24;
+  --red: #f87171;
+  --slate: #8b93a7;
+
+  --mono: 'Geist Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  --sans: 'Inter', system-ui, -apple-system, sans-serif;
+
+  --radius: 14px;
+  --radius-sm: 9px;
+  --maxw: 1080px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  background:
+    radial-gradient(1200px 700px at 78% -8%, rgba(139, 92, 246, 0.16), transparent 60%),
+    radial-gradient(900px 600px at 8% 0%, rgba(245, 158, 11, 0.08), transparent 55%),
+    var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 15px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--brand-3);
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+
+code,
+kbd,
+pre {
+  font-family: var(--mono);
+}
+
+/* ---------- layout ---------- */
+.shell {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 24px 96px;
+}
+
+.topnav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(14px);
+  background: linear-gradient(180deg, rgba(11, 9, 16, 0.92), rgba(11, 9, 16, 0.66));
+  border-bottom: 1px solid var(--border);
+}
+.topnav-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  gap: 22px;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+.brand .dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--brand), var(--warm));
+  box-shadow: 0 0 16px rgba(139, 92, 246, 0.7);
+}
+.brand .mono {
+  font-family: var(--mono);
+  font-size: 14px;
+}
+.navlinks {
+  display: flex;
+  gap: 6px;
+  margin-left: auto;
+}
+.navlinks a {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--muted);
+  padding: 7px 13px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+.navlinks a:hover {
+  color: var(--text);
+  text-decoration: none;
+  background: var(--panel);
+}
+.navlinks a.active {
+  color: var(--text);
+  border-color: var(--border-strong);
+  background: var(--panel-2);
+}
+
+/* ---------- landing ---------- */
+.hero {
+  padding: 88px 0 40px;
+  text-align: center;
+}
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--warm);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 14px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel);
+}
+.hero h1 {
+  font-size: clamp(40px, 7vw, 76px);
+  line-height: 1.02;
+  letter-spacing: -0.035em;
+  font-weight: 800;
+  margin: 26px auto 0;
+  max-width: 14ch;
+}
+.grad {
+  background: linear-gradient(100deg, var(--brand-3) 0%, var(--brand) 32%, var(--warm) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.hero .lede {
+  font-size: clamp(16px, 2.2vw, 20px);
+  color: var(--muted);
+  max-width: 60ch;
+  margin: 24px auto 0;
+}
+.install {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 34px;
+  padding: 13px 18px;
+  border-radius: 12px;
+  border: 1px solid var(--border-strong);
+  background: var(--panel-2);
+  font-family: var(--mono);
+  font-size: 14.5px;
+}
+.install .prompt {
+  color: var(--brand-3);
+}
+.install .pkg {
+  color: var(--text);
+}
+.install .copy {
+  color: var(--faint);
+  font-size: 12px;
+  border-left: 1px solid var(--border);
+  padding-left: 12px;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 34px;
+}
+.chip {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--text);
+  padding: 8px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+}
+.chip .k {
+  color: var(--faint);
+  margin-right: 8px;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+  margin-top: 72px;
+}
+.feature {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 22px;
+  background: linear-gradient(180deg, var(--panel-2), transparent);
+}
+.feature h3 {
+  margin: 0 0 8px;
+  font-size: 17px;
+  letter-spacing: -0.01em;
+}
+.feature p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+.feature .tag {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--brand-3);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.readme-block {
+  margin-top: 64px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 32px 24px;
+  background: var(--panel);
+}
+
+/* ---------- page headers ---------- */
+.page-head {
+  padding: 56px 0 8px;
+}
+.page-head h2 {
+  font-size: clamp(28px, 4vw, 40px);
+  letter-spacing: -0.03em;
+  margin: 6px 0 0;
+}
+.page-head p {
+  color: var(--muted);
+  max-width: 70ch;
+  margin: 12px 0 0;
+}
+.page-kicker {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--brand-3);
+}
+
+.section-title {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin: 48px 0 14px;
+  border-top: 1px solid var(--border);
+  padding-top: 22px;
+}
+
+/* ---------- prose (markdown) ---------- */
+.prose {
+  color: var(--text);
+}
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4 {
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+  margin: 1.6em 0 0.5em;
+}
+.prose h2 {
+  font-size: 22px;
+}
+.prose h3 {
+  font-size: 18px;
+}
+.prose p,
+.prose li {
+  color: #d8d2ea;
+}
+.prose a {
+  border-bottom: 1px solid rgba(168, 85, 247, 0.4);
+}
+.prose code {
+  background: rgba(139, 92, 246, 0.12);
+  border: 1px solid var(--border);
+  padding: 1px 6px;
+  border-radius: 6px;
+  font-size: 0.86em;
+  color: #e9d9ff;
+}
+.prose pre {
+  background: #0a0712;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px 18px;
+  overflow-x: auto;
+}
+.prose pre code {
+  background: none;
+  border: none;
+  padding: 0;
+}
+.prose blockquote {
+  border-left: 3px solid var(--brand);
+  margin: 1em 0;
+  padding: 2px 16px;
+  color: var(--muted);
+}
+.prose ul {
+  padding-left: 1.2em;
+}
+
+/* ---------- badges & chips ---------- */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid;
+}
+.badge.accepted {
+  color: var(--green);
+  border-color: rgba(52, 211, 153, 0.4);
+  background: rgba(52, 211, 153, 0.08);
+}
+.badge.proposed {
+  color: var(--amber);
+  border-color: rgba(251, 191, 36, 0.4);
+  background: rgba(251, 191, 36, 0.08);
+}
+.badge.superseded {
+  color: var(--slate);
+  border-color: var(--border);
+  background: var(--panel);
+}
+.badge.neutral {
+  color: var(--muted);
+  border-color: var(--border);
+  background: var(--panel);
+}
+
+.govchip {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--brand-3);
+  padding: 3px 9px;
+  border-radius: 7px;
+  border: 1px solid rgba(139, 92, 246, 0.28);
+  background: rgba(139, 92, 246, 0.08);
+}
+
+/* ---------- decisions ---------- */
+.decision {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 26px 28px;
+  margin-top: 22px;
+  background: linear-gradient(180deg, var(--panel-2), transparent);
+  scroll-margin-top: 84px;
+}
+.decision.superseded {
+  opacity: 0.78;
+}
+.decision-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.decision-id {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--faint);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 3px 9px;
+}
+.decision-head h3 {
+  margin: 0;
+  font-size: 22px;
+  letter-spacing: -0.02em;
+  flex: 1 1 auto;
+}
+.decision.superseded .decision-head h3 {
+  text-decoration: line-through;
+  color: var(--muted);
+}
+.field-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin: 22px 0 8px;
+}
+.proposition {
+  font-size: 17px;
+  color: #e4def2;
+  border-left: 3px solid var(--warm);
+  padding-left: 16px;
+}
+.decision-statement {
+  font-size: 16px;
+  border-left: 3px solid var(--brand);
+  padding: 8px 16px;
+  background: rgba(139, 92, 246, 0.06);
+  border-radius: 0 8px 8px 0;
+}
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.option {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  padding: 11px 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel);
+}
+.option.chosen {
+  border-color: rgba(52, 211, 153, 0.45);
+  background: rgba(52, 211, 153, 0.06);
+}
+.option.notchosen {
+  opacity: 0.5;
+}
+.option .mark {
+  font-family: var(--mono);
+  font-size: 14px;
+  width: 16px;
+  flex: 0 0 auto;
+}
+.option.chosen .mark {
+  color: var(--green);
+}
+.option.notchosen .mark {
+  color: var(--faint);
+}
+.option .oid {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--text);
+}
+.option .osum {
+  color: var(--muted);
+  font-size: 14px;
+}
+.option.chosen .osum {
+  color: #d8d2ea;
+}
+.governs-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+/* ---------- schema table ---------- */
+.schema-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-top: 20px;
+  overflow: hidden;
+  background: var(--panel);
+}
+.schema-card-head {
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--border);
+  background: linear-gradient(180deg, var(--panel-2), transparent);
+}
+.schema-card-head .file {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--brand-3);
+}
+.schema-card-head h3 {
+  margin: 6px 0 0;
+  font-size: 19px;
+  letter-spacing: -0.02em;
+}
+.schema-card-head .desc {
+  color: var(--muted);
+  font-size: 14px;
+  margin-top: 8px;
+  max-width: 80ch;
+}
+.schema-flags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+.flag {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 2px 8px;
+}
+
+.fields {
+  padding: 8px 10px 14px;
+}
+.frow {
+  position: relative;
+  padding: 10px 12px;
+  border-radius: 9px;
+}
+.frow:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+.frow-main {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.fname {
+  font-family: var(--mono);
+  font-size: 14px;
+  color: var(--text);
+  font-weight: 500;
+}
+.fname.anykey {
+  color: var(--warm);
+}
+.ftype {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--brand-3);
+  background: rgba(139, 92, 246, 0.1);
+  border: 1px solid rgba(139, 92, 246, 0.22);
+  border-radius: 6px;
+  padding: 1px 8px;
+}
+.freq {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid;
+}
+.freq.yes {
+  color: var(--warm);
+  border-color: rgba(245, 158, 11, 0.4);
+  background: rgba(245, 158, 11, 0.08);
+}
+.freq.no {
+  color: var(--faint);
+  border-color: var(--border);
+}
+.freq.conditional {
+  color: var(--teal);
+  border-color: rgba(45, 212, 191, 0.4);
+  background: rgba(45, 212, 191, 0.08);
+}
+.fdesc {
+  color: var(--muted);
+  font-size: 13.5px;
+  margin-top: 5px;
+}
+.fmeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 7px;
+}
+.fmeta .pill {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1px 7px;
+}
+.fmeta .pill.enumv {
+  color: #d8d2ea;
+  background: var(--panel);
+}
+.fmeta .pill.constv {
+  color: var(--green);
+  border-color: rgba(52, 211, 153, 0.35);
+}
+.fmeta .pill.cond {
+  color: var(--teal);
+  border-color: rgba(45, 212, 191, 0.35);
+}
+.fchildren {
+  margin: 6px 0 2px 8px;
+  padding-left: 14px;
+  border-left: 1px solid var(--border-strong);
+}
+.fchildren-label {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin: 6px 0 2px 12px;
+}
+
+/* ---------- misc ---------- */
+.empty {
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius);
+  padding: 28px;
+  color: var(--muted);
+  text-align: center;
+  margin-top: 22px;
+  font-family: var(--mono);
+  font-size: 13.5px;
+}
+.footer {
+  margin-top: 80px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border);
+  color: var(--faint);
+  font-family: var(--mono);
+  font-size: 12px;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* ---------- spec ↔ decision interaction ---------- */
+/* A field a decision shaped is a doorway to that decision (decision 0032). */
+.frow.has-dec > .frow-main {
+  cursor: pointer;
+}
+.frow.has-dec > .frow-main:hover .fname {
+  color: var(--brand-3);
+}
+.fwhy {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--brand-3);
+  background: rgba(139, 92, 246, 0.1);
+  border: 1px solid rgba(139, 92, 246, 0.28);
+  border-radius: 999px;
+  padding: 1px 9px;
+  white-space: nowrap;
+  user-select: none;
+}
+.frow-main:hover .fwhy {
+  background: rgba(139, 92, 246, 0.18);
+  border-color: rgba(139, 92, 246, 0.5);
+}
+.frow.open {
+  background: rgba(139, 92, 246, 0.05);
+  outline: 1px solid rgba(139, 92, 246, 0.22);
+}
+.fwhy.btn {
+  font: inherit;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  cursor: pointer;
+}
+.schema-root-dec {
+  margin-top: 14px;
+}
+.field-decisions {
+  margin: 12px 0 4px;
+  padding-left: 14px;
+  border-left: 2px solid rgba(139, 92, 246, 0.4);
+}
+.field-decisions .decision {
+  margin-top: 12px;
+  background: var(--bg-2);
+}
+.field-decisions .decision:first-child {
+  margin-top: 0;
+}

--- a/design/web/src/types.ts
+++ b/design/web/src/types.ts
@@ -1,0 +1,104 @@
+export type DecisionStatus = 'proposed' | 'accepted' | 'superseded' | string
+
+export interface DecisionOption {
+  id: string
+  summary: string
+  chosen: boolean
+}
+
+export interface Decision {
+  id: number
+  slug: string
+  title: string
+  status: DecisionStatus
+  date?: string
+  proposition?: string
+  options: DecisionOption[]
+  decision?: string
+  governs: string[]
+  supersedes: (string | number)[]
+  /** Feature/spec-area slugs this decision produces (graph: decision → feature). */
+  feature: string[]
+  /** Ids of decisions this one builds on (graph: dep → this). */
+  dependsOn: number[]
+  /** Raw markdown body after frontmatter. */
+  body: string
+  /** Source filename, e.g. 0001-decisions-gate-code.md */
+  file: string
+}
+
+/** A capability / spec-area node, defined in design/features.yaml. */
+export interface Feature {
+  id: string
+  title: string
+  blurb?: string
+  /** path (optionally with #fragment) of the spec this feature lands in */
+  spec?: string
+}
+
+export interface ContractPage {
+  title: string
+  order: number
+  body: string
+  file: string
+  slug: string
+}
+
+export interface SchemaDoc {
+  /** filename, e.g. run.schema.json */
+  file: string
+  /** raw parsed JSON Schema */
+  schema: JSONSchema
+}
+
+/** Intentionally loose — JSON Schema is dynamic. */
+export interface JSONSchema {
+  $schema?: string
+  $id?: string
+  title?: string
+  description?: string
+  type?: string | string[]
+  const?: unknown
+  enum?: unknown[]
+  format?: string
+  pattern?: string
+  minLength?: number
+  maxLength?: number
+  minimum?: number
+  maximum?: number
+  required?: string[]
+  properties?: Record<string, JSONSchema>
+  additionalProperties?: boolean | JSONSchema
+  items?: JSONSchema
+  $ref?: string
+  $defs?: Record<string, JSONSchema>
+  allOf?: JSONSchema[]
+  [k: string]: unknown
+}
+
+export type RequiredKind = 'yes' | 'no' | 'conditional'
+
+export interface RequiredInfo {
+  kind: RequiredKind
+  /** human note for conditional, e.g. "required when status = finalized" */
+  note?: string
+}
+
+export interface FieldNode {
+  name: string
+  typeLabel: string
+  required: RequiredInfo
+  description?: string
+  enumValues?: unknown[]
+  constValue?: unknown
+  constraints: string[]
+  /** label describing the relationship of children to this node */
+  childrenLabel?: string
+  children: FieldNode[]
+  /**
+   * JSON Pointer of this node within its schema (e.g. /properties/totals,
+   * /$defs/step/properties/status). Combined with the schema filename it forms
+   * the `governs` key used to find the decisions that shaped this key.
+   */
+  pointer: string
+}

--- a/design/web/tsconfig.json
+++ b/design/web/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/design/web/vite.config.ts
+++ b/design/web/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
+
+// The viewer lives at design/web/ and reads sibling content under design/
+// (decisions, contract, schemas, README) via import.meta.glob with ../ paths.
+// We must allow Vite's dev file-server to read those parent dirs.
+const webRoot = fileURLToPath(new URL('.', import.meta.url))
+const designRoot = fileURLToPath(new URL('..', import.meta.url))
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    fs: {
+      allow: [webRoot, designRoot],
+    },
+  },
+})

--- a/design/web/vite.config.ts
+++ b/design/web/vite.config.ts
@@ -7,12 +7,15 @@ import { fileURLToPath, URL } from 'node:url'
 // We must allow Vite's dev file-server to read those parent dirs.
 const webRoot = fileURLToPath(new URL('.', import.meta.url))
 const designRoot = fileURLToPath(new URL('..', import.meta.url))
+// The L0 schemas now live at <repo>/src/schemas/0.1/L0 (decision 0038), outside
+// design/, so the dev file-server must also be allowed to read the repo root.
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
 
 export default defineConfig({
   plugins: [react()],
   server: {
     fs: {
-      allow: [webRoot, designRoot],
+      allow: [webRoot, designRoot, repoRoot],
     },
   },
 })

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,49 @@
+# Conformance fixtures
+
+Example packs that pin the L0 contract. They are illustrative now and become the
+input corpus for the `validate` test suite once `src/` lands.
+
+## `valid-L0/`
+
+### `smoke.evidence/` — a finalized pack that fully conforms
+- `run.yaml`: `status: finalized`, with `ended` and `totals` present.
+- `totals: { tests: 2, passed: 1, failed: 1, broken: 0, skipped: 0 }` — **agrees**
+  with the two per-test verdicts (`checkout` passed, `login` failed).
+- Each `tests/<id>/` has an opaque `test.md` definition plus a `result.yaml` whose
+  `definition.sha256` is the **real** hash of that `test.md`.
+- Shows optional fields in use: `metrics` (`{value, type}`), `environment`, per-step
+  `kind`/`defect`/`expected`/`actual`/`check`, `tags`, `requirements`.
+
+## `invalid-L0/`
+
+Each pack isolates a single violation.
+
+### `totals-mismatch.evidence/`
+`status: finalized` and structurally fine, but `totals` claims `passed: 1, failed: 0`
+while the one test's verdict is `failed`. On a finalized pack, totals **must** agree
+with the rolled-up verdicts → invalid. (Decisions 0011, 0018.)
+
+### `missing-status.evidence/`
+`status: running` (so absent `ended`/`totals` is fine), but
+`tests/checkout/result.yaml` omits the required `status` field. A missing required
+field is invalid at any run status. (Decision 0015.)
+
+### `path-escape.evidence/`
+`status: running` and otherwise fine, but `tests/checkout/result.yaml` declares
+`definition.path: ../shared/test.md`, which escapes the test directory.
+`definition.path` must be a contained relative path at any run status → invalid.
+(Decisions 0029, 0031.)
+
+### `ordinal-collision.evidence/`
+`status: running` and otherwise fine, but the two steps in
+`tests/checkout/result.yaml` both claim `ordinal: 1`. Step ordinals must be unique
+and strictly increasing in array order (gaps are allowed) → invalid. (Decisions
+0030, 0031.)
+
+## Regenerating definition hashes
+
+`definition.sha256` values are real. If you edit a `test.md`, recompute:
+
+```bash
+printf 'sha256:%s\n' "$(shasum -a 256 path/to/test.md | cut -d' ' -f1)"
+```

--- a/fixtures/finalize-L0/running.evidence/run.yaml
+++ b/fixtures/finalize-L0/running.evidence/run.yaml
@@ -1,0 +1,6 @@
+# A live, in-flight pack: no ended/totals yet. `evidence finalize` derives them.
+evidence: "0.1"
+run_id: 2026-06-28-running
+status: running
+title: Running pack to finalize
+started: 2026-06-28T09:00:00Z

--- a/fixtures/finalize-L0/running.evidence/tests/checkout/result.yaml
+++ b/fixtures/finalize-L0/running.evidence/tests/checkout/result.yaml
@@ -1,0 +1,8 @@
+evidence: "0.1"
+test: checkout
+status: passed
+definition:
+  path: test.md
+steps:
+  - { id: open, ordinal: 1, status: passed }
+  - { id: pay,  ordinal: 2, status: passed }

--- a/fixtures/finalize-L0/running.evidence/tests/checkout/test.md
+++ b/fixtures/finalize-L0/running.evidence/tests/checkout/test.md
@@ -1,0 +1,2 @@
+# Checkout
+A definition whose hash finalize will compute and write.

--- a/fixtures/invalid-L0/ended-before-started.evidence/run.yaml
+++ b/fixtures/invalid-L0/ended-before-started.evidence/run.yaml
@@ -1,0 +1,8 @@
+evidence: "0.1"
+run_id: 2026-06-28-timewarp
+status: finalized
+title: ended before started (INVALID)
+started: 2026-06-28T09:05:00Z
+# INVALID: ended precedes started. (Decision 0031, full-seal check.)
+ended: 2026-06-28T09:00:00Z
+totals: { tests: 1, passed: 1, failed: 0, broken: 0, skipped: 0 }

--- a/fixtures/invalid-L0/ended-before-started.evidence/tests/checkout/result.yaml
+++ b/fixtures/invalid-L0/ended-before-started.evidence/tests/checkout/result.yaml
@@ -1,0 +1,7 @@
+evidence: "0.1"
+test: checkout
+status: passed
+definition:
+  path: test.md
+steps:
+  - { id: open, ordinal: 1, status: passed }

--- a/fixtures/invalid-L0/ended-before-started.evidence/tests/checkout/test.md
+++ b/fixtures/invalid-L0/ended-before-started.evidence/tests/checkout/test.md
@@ -1,0 +1,2 @@
+# Checkout
+Timestamps are inverted at the run level.

--- a/fixtures/invalid-L0/hash-mismatch.evidence/run.yaml
+++ b/fixtures/invalid-L0/hash-mismatch.evidence/run.yaml
@@ -1,0 +1,7 @@
+evidence: "0.1"
+run_id: 2026-06-28-hashbad
+status: finalized
+title: Hash mismatch (INVALID)
+started: 2026-06-28T09:00:00Z
+ended: 2026-06-28T09:00:10Z
+totals: { tests: 1, passed: 1, failed: 0, broken: 0, skipped: 0 }

--- a/fixtures/invalid-L0/hash-mismatch.evidence/tests/checkout/result.yaml
+++ b/fixtures/invalid-L0/hash-mismatch.evidence/tests/checkout/result.yaml
@@ -1,0 +1,9 @@
+evidence: "0.1"
+test: checkout
+status: passed
+definition:
+  path: test.md
+  # INVALID: this is not the sha256 of test.md (all zeros). (Decisions 0011/0018/0031.)
+  sha256: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+steps:
+  - { id: open, ordinal: 1, status: passed }

--- a/fixtures/invalid-L0/hash-mismatch.evidence/tests/checkout/test.md
+++ b/fixtures/invalid-L0/hash-mismatch.evidence/tests/checkout/test.md
@@ -1,0 +1,2 @@
+# Checkout
+Definition whose real hash will not match the declared one.

--- a/fixtures/invalid-L0/missing-status.evidence/run.yaml
+++ b/fixtures/invalid-L0/missing-status.evidence/run.yaml
@@ -1,0 +1,8 @@
+evidence: "0.1"
+run_id: 2026-06-19-running
+status: running
+title: Missing status (INVALID)
+started: 2026-06-19T10:00:00Z
+# This pack is `running`, so `ended`/`totals` are legitimately absent (structure-only
+# validation). The violation is in tests/checkout/result.yaml, which omits the
+# required `status` field — invalid regardless of run status.

--- a/fixtures/invalid-L0/missing-status.evidence/tests/checkout/result.yaml
+++ b/fixtures/invalid-L0/missing-status.evidence/tests/checkout/result.yaml
@@ -1,0 +1,9 @@
+evidence: "0.1"
+test: checkout
+# INVALID: `status` is required on every result.yaml (it is the test verdict).
+# This file omits it. A missing required field fails validation at ANY run status.
+# See decision 0015 (result.yaml mandatory cut).
+definition:
+  path: test.md
+steps:
+  - { id: open-checkout, ordinal: 1, status: passed, kind: navigate }

--- a/fixtures/invalid-L0/missing-status.evidence/tests/checkout/test.md
+++ b/fixtures/invalid-L0/missing-status.evidence/tests/checkout/test.md
@@ -1,0 +1,9 @@
+# Checkout
+
+## objective
+A returning customer can buy a single item with a saved card.
+
+## steps
+- Open the checkout page from the cart.
+- Confirm the saved card and place the order.
+- See the order-confirmation screen with an order id.

--- a/fixtures/invalid-L0/ordinal-collision.evidence/run.yaml
+++ b/fixtures/invalid-L0/ordinal-collision.evidence/run.yaml
@@ -1,0 +1,9 @@
+evidence: "0.1"
+run_id: 2026-06-19-ordinal-collision
+status: running
+title: Step ordinal collision (INVALID)
+started: 2026-06-19T10:00:00Z
+# This pack is `running`, so `ended`/`totals` are legitimately absent. The
+# violation is in tests/checkout/result.yaml: two steps share ordinal 1. Step
+# ordinals MUST be unique and strictly increasing in array order (gaps are fine).
+# See decisions 0030 (ordinal semantics) and 0031 (validator cross-checks).

--- a/fixtures/invalid-L0/ordinal-collision.evidence/tests/checkout/result.yaml
+++ b/fixtures/invalid-L0/ordinal-collision.evidence/tests/checkout/result.yaml
@@ -1,0 +1,10 @@
+evidence: "0.1"
+test: checkout
+status: passed
+definition:
+  path: test.md
+steps:
+  # INVALID: both steps claim ordinal 1. Ordinals must be unique and strictly
+  # increasing in array order. (Decision 0030.)
+  - { id: open-checkout, ordinal: 1, status: passed, kind: navigate }
+  - { id: place-order,   ordinal: 1, status: passed, kind: assertion }

--- a/fixtures/invalid-L0/ordinal-collision.evidence/tests/checkout/test.md
+++ b/fixtures/invalid-L0/ordinal-collision.evidence/tests/checkout/test.md
@@ -1,0 +1,9 @@
+# Checkout
+
+## objective
+A returning customer can buy a single item with a saved card.
+
+## steps
+- Open the checkout page from the cart.
+- Confirm the saved card and place the order.
+- See the order-confirmation screen with an order id.

--- a/fixtures/invalid-L0/path-escape.evidence/run.yaml
+++ b/fixtures/invalid-L0/path-escape.evidence/run.yaml
@@ -1,0 +1,9 @@
+evidence: "0.1"
+run_id: 2026-06-19-path-escape
+status: running
+title: Definition path escape (INVALID)
+started: 2026-06-19T10:00:00Z
+# This pack is `running`, so `ended`/`totals` are legitimately absent. The
+# violation is in tests/checkout/result.yaml: its `definition.path` escapes the
+# test directory with `../`. A contained relative path is required at ANY run
+# status. See decisions 0029 (definition path safety) and 0031 (validator cross-checks).

--- a/fixtures/invalid-L0/path-escape.evidence/tests/checkout/result.yaml
+++ b/fixtures/invalid-L0/path-escape.evidence/tests/checkout/result.yaml
@@ -1,0 +1,9 @@
+evidence: "0.1"
+test: checkout
+status: passed
+definition:
+  # INVALID: path escapes the test directory. `definition.path` MUST be a
+  # contained relative path — no leading `/`, no `..` segment. (Decision 0029.)
+  path: ../shared/test.md
+steps:
+  - { id: open-checkout, ordinal: 1, status: passed, kind: navigate }

--- a/fixtures/invalid-L0/path-escape.evidence/tests/checkout/test.md
+++ b/fixtures/invalid-L0/path-escape.evidence/tests/checkout/test.md
@@ -1,0 +1,9 @@
+# Checkout
+
+## objective
+A returning customer can buy a single item with a saved card.
+
+## steps
+- Open the checkout page from the cart.
+- Confirm the saved card and place the order.
+- See the order-confirmation screen with an order id.

--- a/fixtures/invalid-L0/totals-mismatch.evidence/run.yaml
+++ b/fixtures/invalid-L0/totals-mismatch.evidence/run.yaml
@@ -1,0 +1,10 @@
+evidence: "0.1"
+run_id: 2026-06-19-mismatch
+status: finalized
+title: Totals mismatch (INVALID)
+started: 2026-06-19T10:00:00Z
+ended: 2026-06-19T10:00:30Z
+# INVALID: the single test's verdict is `failed`, but totals claim a pass and no
+# failures. On a finalized pack, totals MUST agree with the rolled-up verdicts.
+# See decision 0011 (totals derived by finalize) and 0018 (status-gated validation).
+totals: { tests: 1, passed: 1, failed: 0, broken: 0, skipped: 0 }

--- a/fixtures/invalid-L0/totals-mismatch.evidence/tests/checkout/result.yaml
+++ b/fixtures/invalid-L0/totals-mismatch.evidence/tests/checkout/result.yaml
@@ -1,0 +1,9 @@
+evidence: "0.1"
+test: checkout
+status: failed
+definition:
+  path: test.md
+  sha256: "sha256:b9148b426bf0543939c5214ba09adf4309d8f24776b69724e50e806f0ca35258"
+steps:
+  - { id: open-checkout, ordinal: 1, status: passed, kind: navigate }
+  - { id: place-order,   ordinal: 2, status: failed, kind: assertion }

--- a/fixtures/invalid-L0/totals-mismatch.evidence/tests/checkout/test.md
+++ b/fixtures/invalid-L0/totals-mismatch.evidence/tests/checkout/test.md
@@ -1,0 +1,9 @@
+# Checkout
+
+## objective
+A returning customer can buy a single item with a saved card.
+
+## steps
+- Open the checkout page from the cart.
+- Confirm the saved card and place the order.
+- See the order-confirmation screen with an order id.

--- a/fixtures/invalid-L0/version-0.2.evidence/run.yaml
+++ b/fixtures/invalid-L0/version-0.2.evidence/run.yaml
@@ -1,0 +1,5 @@
+evidence: "0.2"
+run_id: 2026-06-28-future
+status: running
+title: A future-version pack (INVALID for a 0.1 validator)
+started: 2026-06-28T09:00:00Z

--- a/fixtures/invalid-L0/version-0.2.evidence/tests/checkout/result.yaml
+++ b/fixtures/invalid-L0/version-0.2.evidence/tests/checkout/result.yaml
@@ -1,0 +1,7 @@
+evidence: "0.2"
+test: checkout
+status: passed
+definition:
+  path: test.md
+steps:
+  - { id: open, ordinal: 1, status: passed }

--- a/fixtures/invalid-L0/version-0.2.evidence/tests/checkout/test.md
+++ b/fixtures/invalid-L0/version-0.2.evidence/tests/checkout/test.md
@@ -1,0 +1,2 @@
+# Checkout
+A future-version definition.

--- a/fixtures/valid-L0/smoke.evidence/run.yaml
+++ b/fixtures/valid-L0/smoke.evidence/run.yaml
@@ -1,0 +1,14 @@
+evidence: "0.1"
+run_id: 2026-06-19-smoke-7f3a
+status: finalized
+title: Nightly smoke
+started: 2026-06-19T10:00:00Z
+ended: 2026-06-19T10:02:14Z
+# totals is DERIVED by `evidence finalize` — it must agree with the per-test verdicts.
+totals: { tests: 2, passed: 1, failed: 1, broken: 0, skipped: 0 }
+metrics:
+  pass_rate: { value: 0.5, type: percentage }
+  duration: { value: 134, type: seconds }
+environment:
+  producer: { name: example-framework, version: 0.1.0 }
+  ci: { provider: github-actions, build: "42" }

--- a/fixtures/valid-L0/smoke.evidence/tests/checkout/result.yaml
+++ b/fixtures/valid-L0/smoke.evidence/tests/checkout/result.yaml
@@ -1,0 +1,11 @@
+evidence: "0.1"
+test: checkout
+status: passed
+definition:
+  path: test.md
+  sha256: "sha256:b9148b426bf0543939c5214ba09adf4309d8f24776b69724e50e806f0ca35258"
+duration_ms: 8400
+steps:
+  - { id: open-checkout,    ordinal: 1, status: passed, kind: navigate,  duration_ms: 3100 }
+  - { id: confirm-order,    ordinal: 2, status: passed, kind: input,     duration_ms: 2200 }
+  - { id: see-confirmation, ordinal: 3, status: passed, kind: assertion, duration_ms: 3100 }

--- a/fixtures/valid-L0/smoke.evidence/tests/checkout/test.md
+++ b/fixtures/valid-L0/smoke.evidence/tests/checkout/test.md
@@ -1,0 +1,9 @@
+# Checkout
+
+## objective
+A returning customer can buy a single item with a saved card.
+
+## steps
+- Open the checkout page from the cart.
+- Confirm the saved card and place the order.
+- See the order-confirmation screen with an order id.

--- a/fixtures/valid-L0/smoke.evidence/tests/login/result.yaml
+++ b/fixtures/valid-L0/smoke.evidence/tests/login/result.yaml
@@ -1,0 +1,25 @@
+evidence: "0.1"
+test: login
+status: failed
+definition:
+  path: test.md
+  sha256: "sha256:c7596aec1575cbbbf4d7d1f909b965c2cd08f9afbfb88b643fe2963db417d029"
+duration_ms: 6100
+tags: [auth, p0]
+requirements: [REQ-AUTH]
+steps:
+  - id: open-signin
+    ordinal: 1
+    status: passed
+    kind: navigate
+    duration_ms: 2600
+  - id: submit-credentials
+    ordinal: 2
+    status: failed
+    kind: assertion
+    duration_ms: 3500
+    defect: Product
+    expected: "account dashboard is shown after sign-in"
+    actual: "stayed on /signin with error 'invalid credentials' for known-good user"
+    check:
+      kind: presence

--- a/fixtures/valid-L0/smoke.evidence/tests/login/test.md
+++ b/fixtures/valid-L0/smoke.evidence/tests/login/test.md
@@ -1,0 +1,9 @@
+# Login
+
+## objective
+A registered user can sign in with email and password.
+
+## steps
+- Open the sign-in page.
+- Enter valid credentials and submit.
+- Land on the account dashboard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1579 @@
+{
+  "name": "evidence-cli",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "evidence-cli",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.5.14",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "commander": "^12.1.0",
+        "picocolors": "^1.0.1",
+        "yaml": "^2.5.0"
+      },
+      "bin": {
+        "evidence": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/adm-zip": "^0.5.5",
+        "@types/node": "^20.14.0",
+        "typescript": "^5.5.0",
+        "vitest": "^2.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,30 @@
   "description": "An open, framework-agnostic format for what a test run produced — and the CLI that seals and validates it.",
   "license": "MIT",
   "private": true,
+  "bin": { "evidence": "dist/cli.js" },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
   "scripts": {
+    "build": "tsc && node scripts/copy-schemas.mjs",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "docs": "npm --prefix design/web run dev",
     "docs:build": "npm --prefix design/web run build",
     "docs:install": "npm --prefix design/web install"
+  },
+  "dependencies": {
+    "adm-zip": "^0.5.14",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
+    "commander": "^12.1.0",
+    "picocolors": "^1.0.1",
+    "yaml": "^2.5.0"
+  },
+  "devDependencies": {
+    "@types/adm-zip": "^0.5.5",
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "evidence-cli",
+  "version": "0.0.0",
+  "description": "An open, framework-agnostic format for what a test run produced — and the CLI that seals and validates it.",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "docs": "npm --prefix design/web run dev",
+    "docs:build": "npm --prefix design/web run build",
+    "docs:install": "npm --prefix design/web install"
+  }
+}

--- a/scripts/copy-schemas.mjs
+++ b/scripts/copy-schemas.mjs
@@ -1,0 +1,10 @@
+// Copies the canonical schema JSON next to the compiled registry so the
+// published dist/ package can require() them. src/schemas remains the single
+// authored source of truth (decision 0038).
+import { cpSync } from "node:fs";
+
+cpSync("src/schemas", "dist/schemas", {
+  recursive: true,
+  filter: (src) => !src.endsWith(".ts"),
+});
+console.log("copied src/schemas/**/*.json -> dist/schemas");

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+
+const ROOT = path.resolve(__dirname, "..");
+const CLI = path.join(ROOT, "dist", "cli.js");
+const FIX = path.join(ROOT, "fixtures");
+
+interface Run {
+  status: number;
+  stdout: string;
+}
+
+function run(args: string[]): Run {
+  try {
+    const stdout = execFileSync("node", [CLI, ...args], { encoding: "utf8" });
+    return { status: 0, stdout };
+  } catch (e: any) {
+    return { status: e.status ?? 1, stdout: (e.stdout ?? "").toString() };
+  }
+}
+
+describe("evidence CLI", () => {
+  beforeAll(() => {
+    execFileSync("npm", ["run", "build"], { cwd: ROOT, stdio: "inherit" });
+  }, 120_000);
+
+  it("exits 0 on the valid smoke pack", () => {
+    const r = run(["validate", path.join(FIX, "valid-L0/smoke.evidence"), "--profile", "L0"]);
+    expect(r.status).toBe(0);
+  });
+
+  it("exits 1 on an invalid pack and --json emits the report", () => {
+    const r = run(["validate", path.join(FIX, "invalid-L0/totals-mismatch.evidence"), "--json"]);
+    expect(r.status).toBe(1);
+    const report = JSON.parse(r.stdout);
+    expect(report.valid).toBe(false);
+    expect(report.diagnostics.some((d: any) => d.code === "totals.mismatch")).toBe(true);
+  });
+
+  it("exits 2 (usage) when finalize is given a non-directory", () => {
+    const r = run(["finalize", path.join(FIX, "valid-L0/smoke.evidence/run.yaml")]);
+    expect(r.status).toBe(2);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import { validate } from "./validate";
+import { finalize } from "./finalize";
+import { loadConfig, resolveProfile } from "./config";
+import { makeReporter } from "./report/reporter";
+
+const program = new Command();
+program
+  .name("evidence")
+  .description("Validate and finalize .evidence packs")
+  .version("0.0.0");
+
+program
+  .command("validate")
+  .argument("<target>", "a <name>.evidence directory or a sealed .evidence zip")
+  .option("--profile <profile>", "validation profile (overrides config)")
+  .option("--config <path>", "path to config.json")
+  .option("--json", "machine-readable output", false)
+  .action(async (target: string, opts: { profile?: string; config?: string; json: boolean }) => {
+    const reporter = makeReporter(opts.json);
+    try {
+      const config = await loadConfig(opts.config);
+      const profile = resolveProfile(opts.profile, config);
+      const report = await validate(target, { profile });
+      reporter.validation(report);
+      process.exit(report.valid ? 0 : 1);
+    } catch (e: any) {
+      reporter.usageError(e?.message ?? String(e));
+      process.exit(2);
+    }
+  });
+
+program
+  .command("finalize")
+  .argument("<dir>", "the live <name>.evidence/ directory")
+  .option("--config <path>", "path to config.json")
+  .option("--json", "machine-readable output", false)
+  .action(async (dir: string, opts: { config?: string; json: boolean }) => {
+    const reporter = makeReporter(opts.json);
+    try {
+      const result = await finalize(dir, { endedAt: new Date().toISOString() });
+      reporter.finalize(result);
+      process.exit(0);
+    } catch (e: any) {
+      reporter.usageError(e?.message ?? String(e));
+      process.exit(2);
+    }
+  });
+
+program.parseAsync(process.argv).catch((e) => {
+  process.stderr.write(String(e) + "\n");
+  process.exit(2);
+});

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadConfig, resolveProfile, configPath } from "./config";
+
+describe("config", () => {
+  it("resolves --flag over config over the L0 default", () => {
+    expect(resolveProfile("L1", { defaultProfile: "L2" })).toBe("L1");
+    expect(resolveProfile(undefined, { defaultProfile: "L2" })).toBe("L2");
+    expect(resolveProfile(undefined, {})).toBe("L0");
+  });
+
+  it("treats a missing config file as empty", async () => {
+    const missing = path.join(os.tmpdir(), "evi-nope-" + Date.now() + ".json");
+    expect(await loadConfig(missing)).toEqual({});
+  });
+
+  it("reads defaultProfile from a JSON config", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "evi-cfg-"));
+    const p = path.join(dir, "config.json");
+    await fs.writeFile(p, JSON.stringify({ defaultProfile: "L0" }));
+    expect(await loadConfig(p)).toEqual({ defaultProfile: "L0" });
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("throws a USAGE error on malformed JSON", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "evi-cfg-"));
+    const p = path.join(dir, "config.json");
+    await fs.writeFile(p, "{ not json");
+    await expect(loadConfig(p)).rejects.toMatchObject({ code: "USAGE" });
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("defaults the config path under ~/.testmuai/evidence", () => {
+    expect(configPath()).toMatch(/[/\\]\.testmuai[/\\]evidence[/\\]config\.json$/);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,35 @@
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { DEFAULT_PROFILE } from "./contract";
+
+export interface EvidenceConfig {
+  defaultProfile?: string;
+}
+
+export function configPath(flag?: string): string {
+  if (flag) return flag;
+  if (process.env.EVIDENCE_CONFIG) return process.env.EVIDENCE_CONFIG;
+  return path.join(os.homedir(), ".testmuai", "evidence", "config.json");
+}
+
+export async function loadConfig(flag?: string): Promise<EvidenceConfig> {
+  const p = configPath(flag);
+  let raw: string;
+  try {
+    raw = await fs.readFile(p, "utf8");
+  } catch {
+    return {}; // a missing config is fine — built-in default applies
+  }
+  try {
+    return JSON.parse(raw) as EvidenceConfig;
+  } catch {
+    const e = new Error(`config at ${p} is not valid JSON`) as Error & { code?: string };
+    e.code = "USAGE";
+    throw e;
+  }
+}
+
+export function resolveProfile(flag: string | undefined, config: EvidenceConfig): string {
+  return flag ?? config.defaultProfile ?? DEFAULT_PROFILE;
+}

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { CONTRACT_VERSION, DEFAULT_PROFILE, Codes } from "./contract";
+
+describe("contract constants", () => {
+  it("pins the contract version to 0.1", () => {
+    expect(CONTRACT_VERSION).toBe("0.1");
+  });
+  it("defaults the profile to L0", () => {
+    expect(DEFAULT_PROFILE).toBe("L0");
+  });
+  it("exposes stable diagnostic codes", () => {
+    expect(Codes.VERSION_UNSUPPORTED).toBe("version.unsupported");
+    expect(Codes.TOTALS_MISMATCH).toBe("totals.mismatch");
+    expect(Codes.ORDINAL_COLLISION).toBe("ordinal.collision");
+  });
+});

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,0 +1,52 @@
+export const CONTRACT_VERSION = "0.1" as const;
+export const DEFAULT_PROFILE = "L0" as const;
+
+export type Verdict = "passed" | "failed" | "broken" | "skipped";
+export type RunStatus = "running" | "finalized" | "aborted";
+export type Severity = "error" | "warning";
+
+export interface Diagnostic {
+  code: string;
+  severity: Severity;
+  location: string;
+  message: string;
+}
+
+export interface ValidationReport {
+  valid: boolean;
+  profile: string;
+  version: string;
+  diagnostics: Diagnostic[];
+}
+
+export interface Totals {
+  tests: number;
+  passed: number;
+  failed: number;
+  broken: number;
+  skipped: number;
+}
+
+export interface FinalizeResult {
+  totals: Totals;
+  sealedPath: string;
+}
+
+export const Codes = {
+  MANIFEST_MISSING: "manifest.missing",
+  MANIFEST_PARSE: "manifest.parse",
+  RESULT_MISSING: "result.missing",
+  RESULT_PARSE: "result.parse",
+  VERSION_UNSUPPORTED: "version.unsupported",
+  SCHEMA: "schema.invalid",
+  TEST_ID_MISMATCH: "test.id_mismatch",
+  DEFINITION_MISSING: "definition.missing",
+  DEFINITION_PATH_ESCAPE: "definition.path_escape",
+  ORDINAL_COLLISION: "ordinal.collision",
+  ORDINAL_NOT_INCREASING: "ordinal.not_increasing",
+  ENDED_BEFORE_STARTED: "ended.before_started",
+  TOTALS_MISMATCH: "totals.mismatch",
+  HASH_MISSING: "definition.hash_missing",
+  HASH_MISMATCH: "definition.hash_mismatch",
+  STATUS_DISAGREES: "status.disagrees_with_steps",
+} as const;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,9 @@
+import type { Diagnostic } from "./contract";
+
+export function err(code: string, location: string, message: string): Diagnostic {
+  return { code, severity: "error", location, message };
+}
+
+export function warn(code: string, location: string, message: string): Diagnostic {
+  return { code, severity: "warning", location, message };
+}

--- a/src/finalize/index.test.ts
+++ b/src/finalize/index.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { finalize } from "./index";
+import { validate } from "../validate";
+import { parseYaml } from "../yaml";
+
+const SRC = path.resolve(__dirname, "../../fixtures/finalize-L0/running.evidence");
+let work: string | undefined;
+
+async function stageCopy(): Promise<string> {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "evi-fin-"));
+  const dst = path.join(tmp, "running.evidence");
+  await fs.cp(SRC, dst, { recursive: true });
+  work = tmp;
+  return dst;
+}
+
+afterEach(async () => {
+  if (work) await fs.rm(work, { recursive: true, force: true });
+  work = undefined;
+});
+
+describe("finalize", () => {
+  it("derives totals, sets finalized+ended, hashes the definition, and seals in place", async () => {
+    const dir = await stageCopy();
+    const result = await finalize(dir, { endedAt: "2026-06-28T09:00:30Z" });
+
+    expect(result.totals).toEqual({ tests: 1, passed: 1, failed: 0, broken: 0, skipped: 0 });
+    // sealed file replaces the directory at the same path (decision 0039)
+    expect(result.sealedPath).toBe(dir);
+    const stat = await fs.stat(dir);
+    expect(stat.isFile()).toBe(true);
+
+    // the sealed pack validates full-seal clean
+    const report = await validate(dir, { profile: "L0" });
+    expect(report.diagnostics.filter((d) => d.severity === "error")).toEqual([]);
+    expect(report.valid).toBe(true);
+  });
+
+  it("rejects a non-directory input as a usage error", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "evi-fin-"));
+    work = tmp;
+    const file = path.join(tmp, "x.evidence");
+    await fs.writeFile(file, "not a directory");
+    await expect(finalize(file, { endedAt: "2026-06-28T09:00:30Z" })).rejects.toMatchObject({ code: "USAGE" });
+  });
+
+  it("preserves the producer's run.yaml comment through write-back", async () => {
+    const dir = await stageCopy();
+    await finalize(dir, { endedAt: "2026-06-28T09:00:30Z" });
+    // unzip the sealed file in memory and inspect run.yaml
+    const AdmZip = (await import("adm-zip")).default;
+    const zip = new AdmZip(dir);
+    const runRaw = zip.getEntry("run.yaml")!.getData().toString("utf8");
+    expect(runRaw).toContain("# A live, in-flight pack");
+    const run = parseYaml(runRaw) as any;
+    expect(run.status).toBe("finalized");
+    expect(run.ended).toBe("2026-06-28T09:00:30Z");
+    expect(run.totals.tests).toBe(1);
+  });
+});

--- a/src/finalize/index.ts
+++ b/src/finalize/index.ts
@@ -1,0 +1,82 @@
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { createHash } from "node:crypto";
+import AdmZip from "adm-zip";
+import { parseYaml, parseDoc, stringifyDoc } from "../yaml";
+import type { FinalizeResult, Totals, Verdict } from "../contract";
+
+export interface FinalizeOptions {
+  /** RFC3339 timestamp to write as run.yaml.ended (caller-supplied for testability). */
+  endedAt: string;
+}
+
+export async function finalize(dir: string, opts: FinalizeOptions): Promise<FinalizeResult> {
+  const stat = await fs.stat(dir).catch(() => null);
+  if (!stat || !stat.isDirectory()) {
+    const e = new Error("finalize requires the live <name>.evidence/ directory, not a sealed zip") as Error & { code?: string };
+    e.code = "USAGE";
+    throw e;
+  }
+
+  const testsDir = path.join(dir, "tests");
+  const testIds = (await fs.readdir(testsDir, { withFileTypes: true }).catch(() => []))
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+
+  const totals: Totals = { tests: 0, passed: 0, failed: 0, broken: 0, skipped: 0 };
+
+  // Derive totals + write each definition.sha256 back into result.yaml.
+  for (const id of testIds) {
+    const resultPath = path.join(testsDir, id, "result.yaml");
+    const raw = await fs.readFile(resultPath, "utf8");
+    const obj = parseYaml(raw) as any;
+
+    totals.tests++;
+    const s = obj?.status as Verdict | undefined;
+    if (s === "passed" || s === "failed" || s === "broken" || s === "skipped") totals[s]++;
+
+    const defPath = obj?.definition?.path;
+    if (typeof defPath === "string" && defPath.length > 0) {
+      const bytes = await fs.readFile(path.join(testsDir, id, defPath));
+      const hash = `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+      const doc = parseDoc(raw);
+      doc.setIn(["definition", "sha256"], hash);
+      await fs.writeFile(resultPath, stringifyDoc(doc), "utf8");
+    }
+  }
+
+  // Write derived run-level fields back, preserving producer formatting.
+  const runPath = path.join(dir, "run.yaml");
+  const runDoc = parseDoc(await fs.readFile(runPath, "utf8"));
+  runDoc.setIn(["status"], "finalized");
+  runDoc.setIn(["ended"], opts.endedAt);
+  runDoc.setIn(["totals"], totals);
+  await fs.writeFile(runPath, stringifyDoc(runDoc), "utf8");
+
+  // Seal: build the flat zip of the directory CONTENTS fully in memory, THEN
+  // remove the directory and write the file in its place (decision 0039).
+  const zip = new AdmZip();
+  await addContents(zip, dir, "");
+  const buffer = zip.toBuffer();
+
+  const sealedPath = dir; // same path; the directory becomes a file
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.writeFile(sealedPath, buffer);
+
+  return { totals, sealedPath };
+}
+
+/** Add a directory's contents to the zip flat (no wrapping folder entry). */
+async function addContents(zip: AdmZip, dir: string, prefix: string): Promise<void> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const abs = path.join(dir, e.name);
+    const rel = prefix ? `${prefix}/${e.name}` : e.name;
+    if (e.isDirectory()) {
+      await addContents(zip, abs, rel);
+    } else {
+      zip.addFile(rel, await fs.readFile(abs));
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,7 @@
+export { validate } from "./validate";
+export type { ValidateOptions } from "./validate";
+export { finalize } from "./finalize";
+export type { FinalizeOptions } from "./finalize";
+export { loadConfig, resolveProfile, configPath } from "./config";
+export type { EvidenceConfig } from "./config";
+export * from "./contract";

--- a/src/pack/container.test.ts
+++ b/src/pack/container.test.ts
@@ -1,0 +1,50 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import AdmZip from "adm-zip";
+import { openContainer } from "./container";
+
+const SMOKE = path.resolve(__dirname, "../../fixtures/valid-L0/smoke.evidence");
+
+async function makeZip(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "evi-zip-"));
+  const zipPath = path.join(dir, "smoke.evidence");
+  const zip = new AdmZip();
+  zip.addLocalFolder(SMOKE); // flat: entries are the directory's contents
+  zip.writeZip(zipPath);
+  return zipPath;
+}
+
+describe("PackContainer parity", () => {
+  let zipPath: string;
+
+  it("reads a directory and a flat zip identically", async () => {
+    zipPath = await makeZip();
+    const dir = await openContainer(SMOKE);
+    const zip = await openContainer(zipPath);
+
+    expect(dir.kind).toBe("directory");
+    expect(zip.kind).toBe("zip");
+
+    expect(await dir.listTestIds()).toEqual(["checkout", "login"]);
+    expect(await zip.listTestIds()).toEqual(["checkout", "login"]);
+
+    expect(await dir.readManifest()).toEqual(await zip.readManifest());
+    expect(await dir.readResult("checkout")).toEqual(await zip.readResult("checkout"));
+
+    expect(await dir.fileExists("checkout", "test.md")).toBe(true);
+    expect(await zip.fileExists("checkout", "test.md")).toBe(true);
+
+    const a = await dir.readBytes("checkout", "test.md");
+    const b = await zip.readBytes("checkout", "test.md");
+    expect(a && b && a.equals(b)).toBe(true);
+
+    expect(dir.name).toBe("smoke");
+    expect(zip.name).toBe("smoke");
+  });
+
+  afterAll(async () => {
+    if (zipPath) await fs.rm(path.dirname(zipPath), { recursive: true, force: true });
+  });
+});

--- a/src/pack/container.ts
+++ b/src/pack/container.ts
@@ -1,0 +1,121 @@
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import AdmZip from "adm-zip";
+
+export interface PackContainer {
+  kind: "directory" | "zip";
+  /** pack name = file/dir base name with the .evidence suffix stripped */
+  name: string;
+  readManifest(): Promise<string | null>;
+  listTestIds(): Promise<string[]>;
+  readResult(testId: string): Promise<string | null>;
+  fileExists(testId: string, relPath: string): Promise<boolean>;
+  readBytes(testId: string, relPath: string): Promise<Buffer | null>;
+}
+
+function stripEvidence(base: string): string {
+  return base.replace(/\.evidence$/, "");
+}
+
+export class DirectoryContainer implements PackContainer {
+  readonly kind = "directory" as const;
+  constructor(private readonly root: string) {}
+
+  get name(): string {
+    return stripEvidence(path.basename(this.root));
+  }
+
+  async readManifest(): Promise<string | null> {
+    return readFileOrNull(path.join(this.root, "run.yaml"));
+  }
+
+  async listTestIds(): Promise<string[]> {
+    try {
+      const entries = await fs.readdir(path.join(this.root, "tests"), {
+        withFileTypes: true,
+      });
+      return entries.filter((e) => e.isDirectory()).map((e) => e.name).sort();
+    } catch {
+      return [];
+    }
+  }
+
+  async readResult(testId: string): Promise<string | null> {
+    return readFileOrNull(path.join(this.root, "tests", testId, "result.yaml"));
+  }
+
+  async fileExists(testId: string, relPath: string): Promise<boolean> {
+    try {
+      await fs.access(path.join(this.root, "tests", testId, relPath));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async readBytes(testId: string, relPath: string): Promise<Buffer | null> {
+    try {
+      return await fs.readFile(path.join(this.root, "tests", testId, relPath));
+    } catch {
+      return null;
+    }
+  }
+}
+
+export class ZipContainer implements PackContainer {
+  readonly kind = "zip" as const;
+  private readonly zip: AdmZip;
+  constructor(private readonly file: string) {
+    this.zip = new AdmZip(file);
+  }
+
+  get name(): string {
+    return stripEvidence(path.basename(this.file));
+  }
+
+  private readEntry(entry: string): string | null {
+    const e = this.zip.getEntry(entry);
+    return e ? e.getData().toString("utf8") : null;
+  }
+
+  async readManifest(): Promise<string | null> {
+    return this.readEntry("run.yaml");
+  }
+
+  async listTestIds(): Promise<string[]> {
+    const ids = new Set<string>();
+    for (const e of this.zip.getEntries()) {
+      const m = e.entryName.match(/^tests\/([^/]+)\//);
+      if (m) ids.add(m[1]);
+    }
+    return [...ids].sort();
+  }
+
+  async readResult(testId: string): Promise<string | null> {
+    return this.readEntry(`tests/${testId}/result.yaml`);
+  }
+
+  async fileExists(testId: string, relPath: string): Promise<boolean> {
+    return this.zip.getEntry(`tests/${testId}/${relPath}`) != null;
+  }
+
+  async readBytes(testId: string, relPath: string): Promise<Buffer | null> {
+    const e = this.zip.getEntry(`tests/${testId}/${relPath}`);
+    return e ? e.getData() : null;
+  }
+}
+
+export async function openContainer(target: string): Promise<PackContainer> {
+  const stat = await fs.stat(target);
+  return stat.isDirectory()
+    ? new DirectoryContainer(target)
+    : new ZipContainer(target);
+}
+
+async function readFileOrNull(p: string): Promise<string | null> {
+  try {
+    return await fs.readFile(p, "utf8");
+  } catch {
+    return null;
+  }
+}

--- a/src/report/reporter.test.ts
+++ b/src/report/reporter.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { JsonReporter, HumanReporter } from "./reporter";
+import type { ValidationReport } from "../contract";
+
+const REPORT: ValidationReport = {
+  valid: false,
+  profile: "L0",
+  version: "0.1",
+  diagnostics: [
+    { code: "totals.mismatch", severity: "error", location: "run.yaml#/totals/passed", message: "boom" },
+  ],
+};
+
+function capture(fn: () => void): string {
+  let out = "";
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation((c: any) => {
+    out += String(c);
+    return true;
+  });
+  fn();
+  spy.mockRestore();
+  return out;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("reporters", () => {
+  it("JsonReporter emits the exact report object", () => {
+    const out = capture(() => new JsonReporter().validation(REPORT));
+    expect(JSON.parse(out)).toEqual(REPORT);
+  });
+
+  it("HumanReporter (non-TTY) emits plain ASCII without the fancy glyph", () => {
+    const out = capture(() => new HumanReporter(false).validation(REPORT));
+    expect(out).toContain("totals.mismatch");
+    expect(out).toContain("invalid");
+    // plain marker, not the fancy glyph
+    expect(out).toContain("x ");
+    expect(out).not.toContain("✗");
+  });
+
+  it("HumanReporter (TTY) uses the ✗ glyph", () => {
+    const out = capture(() => new HumanReporter(true).validation(REPORT));
+    expect(out).toContain("✗");
+  });
+});

--- a/src/report/reporter.ts
+++ b/src/report/reporter.ts
@@ -1,0 +1,67 @@
+import pc from "picocolors";
+import type { ValidationReport, FinalizeResult, Severity } from "../contract";
+
+export interface Reporter {
+  validation(report: ValidationReport): void;
+  finalize(result: FinalizeResult): void;
+  usageError(message: string): void;
+}
+
+export class JsonReporter implements Reporter {
+  validation(report: ValidationReport): void {
+    process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+  }
+  finalize(result: FinalizeResult): void {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  }
+  usageError(message: string): void {
+    process.stderr.write(JSON.stringify({ error: message }, null, 2) + "\n");
+  }
+}
+
+type Marker = Severity | "ok";
+
+export class HumanReporter implements Reporter {
+  private readonly color: boolean;
+  constructor(private readonly isTty: boolean) {
+    this.color = isTty && !process.env.NO_COLOR;
+  }
+
+  private sym(m: Marker): string {
+    if (this.isTty) return m === "error" ? "✗" : m === "warning" ? "⚠" : "✓";
+    return m === "error" ? "x" : m === "warning" ? "!" : "ok";
+  }
+
+  private paint(s: string, m: Marker): string {
+    if (!this.color) return s;
+    return m === "error" ? pc.red(s) : m === "warning" ? pc.yellow(s) : pc.green(s);
+  }
+
+  validation(report: ValidationReport): void {
+    const errors = report.diagnostics.filter((d) => d.severity === "error");
+    const warnings = report.diagnostics.filter((d) => d.severity === "warning");
+    for (const d of report.diagnostics) {
+      const line = `${this.sym(d.severity)} ${d.location}: ${d.message} [${d.code}]`;
+      process.stdout.write(this.paint(line, d.severity) + "\n");
+    }
+    if (report.valid) {
+      process.stdout.write(this.paint(`${this.sym("ok")} valid (profile ${report.profile}, evidence ${report.version})`, "ok") + "\n");
+    } else {
+      process.stdout.write(this.paint(`${this.sym("error")} invalid — ${errors.length} error(s), ${warnings.length} warning(s)`, "error") + "\n");
+    }
+  }
+
+  finalize(result: FinalizeResult): void {
+    const t = result.totals;
+    process.stdout.write(this.paint(`${this.sym("ok")} sealed ${result.sealedPath}`, "ok") + "\n");
+    process.stdout.write(`  totals: tests=${t.tests} passed=${t.passed} failed=${t.failed} broken=${t.broken} skipped=${t.skipped}\n`);
+  }
+
+  usageError(message: string): void {
+    process.stderr.write(this.paint(`${this.sym("error")} ${message}`, "error") + "\n");
+  }
+}
+
+export function makeReporter(json: boolean): Reporter {
+  return json ? new JsonReporter() : new HumanReporter(Boolean(process.stdout.isTTY));
+}

--- a/src/schemas/0.1/L0/result.schema.json
+++ b/src/schemas/0.1/L0/result.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://evidence-cli.dev/schemas/L0/result.schema.json",
+  "$id": "https://evidence-cli.dev/schemas/0.1/L0/result.schema.json",
   "title": "result.yaml (L0)",
   "description": "THE RESULT for one test inside an .evidence pack (tests/<id>/result.yaml): structured, easy-to-parse per-step outcomes. The test's DEFINITION (the framework's own artifact — kane test.md, a .spec.ts, etc.) lives beside this file and is OPAQUE to evidence-cli; it is referenced by `definition`, never parsed.",
   "type": "object",

--- a/src/schemas/0.1/L0/run.schema.json
+++ b/src/schemas/0.1/L0/run.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://evidence-cli.dev/schemas/L0/run.schema.json",
+  "$id": "https://evidence-cli.dev/schemas/0.1/L0/run.schema.json",
   "title": "run.yaml (L0)",
   "description": "Run-level manifest for an .evidence pack. Its presence at the top of a pack is what identifies the pack (the manifest anchor). One pack = one run. evidence-cli is framework-agnostic: nothing here is specific to any test framework.",
   "type": "object",

--- a/src/schemas/compile.test.ts
+++ b/src/schemas/compile.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { loadSchemas } from "./compile";
+
+describe("loadSchemas", () => {
+  it("accepts a minimal valid run.yaml object", () => {
+    const { run } = loadSchemas("0.1", "L0");
+    const ok = run({
+      evidence: "0.1",
+      run_id: "r1",
+      status: "running",
+      title: "t",
+      started: "2026-06-28T09:00:00Z",
+    });
+    expect(ok).toBe(true);
+  });
+
+  it("rejects a run.yaml missing required fields", () => {
+    const { run } = loadSchemas("0.1", "L0");
+    const ok = run({ evidence: "0.1" });
+    expect(ok).toBe(false);
+    expect(run.errors && run.errors.length).toBeGreaterThan(0);
+  });
+
+  it("requires ended+totals once finalized (conditional schema)", () => {
+    const { run } = loadSchemas("0.1", "L0");
+    const ok = run({
+      evidence: "0.1",
+      run_id: "r1",
+      status: "finalized",
+      title: "t",
+      started: "2026-06-28T09:00:00Z",
+    });
+    expect(ok).toBe(false);
+  });
+});

--- a/src/schemas/compile.ts
+++ b/src/schemas/compile.ts
@@ -1,0 +1,28 @@
+import Ajv2020 from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import type { ValidateFunction } from "ajv";
+import { getSchemas } from "./registry";
+
+export interface CompiledSchemas {
+  run: ValidateFunction;
+  result: ValidateFunction;
+}
+
+const cache = new Map<string, CompiledSchemas>();
+
+export function loadSchemas(version: string, profile: string): CompiledSchemas {
+  const key = `${version}/${profile}`;
+  const hit = cache.get(key);
+  if (hit) return hit;
+
+  const { run, result } = getSchemas(version, profile);
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+
+  const compiled: CompiledSchemas = {
+    run: ajv.compile(run),
+    result: ajv.compile(result),
+  };
+  cache.set(key, compiled);
+  return compiled;
+}

--- a/src/schemas/registry.test.ts
+++ b/src/schemas/registry.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getSchemas } from "./registry";
+
+describe("getSchemas", () => {
+  it("returns the run + result schemas for 0.1/L0 with versioned $id", () => {
+    const { run, result } = getSchemas("0.1", "L0");
+    expect((run as any).$id).toBe("https://evidence-cli.dev/schemas/0.1/L0/run.schema.json");
+    expect((result as any).$id).toBe("https://evidence-cli.dev/schemas/0.1/L0/result.schema.json");
+  });
+
+  it("throws on an unknown version", () => {
+    expect(() => getSchemas("0.2", "L0")).toThrow(/version 0\.2/);
+  });
+
+  it("throws on an unknown profile", () => {
+    expect(() => getSchemas("0.1", "L9")).toThrow(/profile L9/);
+  });
+});

--- a/src/schemas/registry.ts
+++ b/src/schemas/registry.ts
@@ -1,0 +1,27 @@
+import runL0 from "./0.1/L0/run.schema.json";
+import resultL0 from "./0.1/L0/result.schema.json";
+
+export interface SchemaPair {
+  run: object;
+  result: object;
+}
+
+// Version-first (decision 0038): one contract version contains its profile
+// ladder. A future breaking 0.2 is a sibling subtree, leaving 0.1 untouched.
+const REGISTRY: Record<string, Record<string, SchemaPair>> = {
+  "0.1": {
+    L0: { run: runL0 as object, result: resultL0 as object },
+  },
+};
+
+export function getSchemas(version: string, profile: string): SchemaPair {
+  const byProfile = REGISTRY[version];
+  if (!byProfile) {
+    throw new Error(`no schemas for contract version ${version}`);
+  }
+  const pair = byProfile[profile];
+  if (!pair) {
+    throw new Error(`no schemas for profile ${profile} at version ${version}`);
+  }
+  return pair;
+}

--- a/src/validate/checks.test.ts
+++ b/src/validate/checks.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import * as path from "node:path";
+import { validate } from "./index";
+import { Codes } from "../contract";
+
+const FIX = path.resolve(__dirname, "../../fixtures");
+
+async function codesFor(rel: string): Promise<string[]> {
+  const r = await validate(path.join(FIX, rel));
+  return r.diagnostics.map((d) => d.code);
+}
+
+describe("validate — cross-checks", () => {
+  it("passes the finalized smoke pack with zero errors", async () => {
+    const r = await validate(path.join(FIX, "valid-L0/smoke.evidence"));
+    expect(r.diagnostics.filter((d) => d.severity === "error")).toEqual([]);
+    expect(r.valid).toBe(true);
+  });
+
+  it("flags totals that disagree with the rolled-up verdicts", async () => {
+    expect(await codesFor("invalid-L0/totals-mismatch.evidence")).toContain(Codes.TOTALS_MISMATCH);
+  });
+
+  it("flags a definition.path that escapes the test directory", async () => {
+    expect(await codesFor("invalid-L0/path-escape.evidence")).toContain(Codes.DEFINITION_PATH_ESCAPE);
+  });
+
+  it("flags colliding step ordinals", async () => {
+    expect(await codesFor("invalid-L0/ordinal-collision.evidence")).toContain(Codes.ORDINAL_COLLISION);
+  });
+
+  it("flags a definition.sha256 that does not match the file", async () => {
+    expect(await codesFor("invalid-L0/hash-mismatch.evidence")).toContain(Codes.HASH_MISMATCH);
+  });
+
+  it("flags ended earlier than started on a finalized pack", async () => {
+    expect(await codesFor("invalid-L0/ended-before-started.evidence")).toContain(Codes.ENDED_BEFORE_STARTED);
+  });
+});

--- a/src/validate/checks.ts
+++ b/src/validate/checks.ts
@@ -1,0 +1,13 @@
+import type { Diagnostic } from "../contract";
+import type { PackContainer } from "../pack/container";
+
+export interface CrossCheckInput {
+  run: unknown;
+  tests: { testId: string; result: unknown }[];
+  container: PackContainer;
+}
+
+// Stub — real cross-checks land in Task 8.
+export async function runCrossChecks(_input: CrossCheckInput): Promise<Diagnostic[]> {
+  return [];
+}

--- a/src/validate/checks.ts
+++ b/src/validate/checks.ts
@@ -1,13 +1,133 @@
-import type { Diagnostic } from "../contract";
+import * as path from "node:path";
+import { createHash } from "node:crypto";
+import { Codes } from "../contract";
+import type { Diagnostic, Totals, Verdict } from "../contract";
+import { err, warn } from "../diagnostics";
 import type { PackContainer } from "../pack/container";
 
+interface TestEntry {
+  testId: string;
+  result: any;
+}
+
 export interface CrossCheckInput {
-  run: unknown;
-  tests: { testId: string; result: unknown }[];
+  run: any;
+  tests: TestEntry[];
   container: PackContainer;
 }
 
-// Stub — real cross-checks land in Task 8.
-export async function runCrossChecks(_input: CrossCheckInput): Promise<Diagnostic[]> {
-  return [];
+export async function runCrossChecks(input: CrossCheckInput): Promise<Diagnostic[]> {
+  const diags: Diagnostic[] = [];
+  const finalized = input.run?.status === "finalized";
+
+  // --- Structure-only (every run status) ---
+  for (const { testId, result } of input.tests) {
+    const loc = `tests/${testId}/result.yaml`;
+
+    // (a) result.test equals the directory name
+    if (result?.test !== undefined && result.test !== testId) {
+      diags.push(err(Codes.TEST_ID_MISMATCH, loc, `result.test "${result.test}" does not match directory name "${testId}"`));
+    }
+
+    // (b)+(c) definition.path declared, contained, and the file exists
+    const defPath = result?.definition?.path;
+    if (typeof defPath === "string" && defPath.length > 0) {
+      if (!isContained(defPath)) {
+        diags.push(err(Codes.DEFINITION_PATH_ESCAPE, `${loc}#/definition/path`, `definition.path "${defPath}" escapes the test directory`));
+      } else if (!(await input.container.fileExists(testId, defPath))) {
+        diags.push(err(Codes.DEFINITION_MISSING, `${loc}#/definition/path`, `definition file "${defPath}" does not exist`));
+      }
+    }
+
+    // (d) ordinals unique and strictly increasing in array order (gaps allowed)
+    const steps: any[] = Array.isArray(result?.steps) ? result.steps : [];
+    let prev = -Infinity;
+    const seen = new Set<number>();
+    steps.forEach((step, i) => {
+      const ord = step?.ordinal;
+      if (typeof ord !== "number") return; // schema catches missing/typed ordinals
+      if (seen.has(ord)) {
+        diags.push(err(Codes.ORDINAL_COLLISION, `${loc}#/steps/${i}/ordinal`, `duplicate step ordinal ${ord}`));
+      }
+      seen.add(ord);
+      if (ord <= prev) {
+        diags.push(err(Codes.ORDINAL_NOT_INCREASING, `${loc}#/steps/${i}/ordinal`, `step ordinal ${ord} is not strictly increasing (previous ${prev})`));
+      }
+      prev = ord;
+    });
+
+    // Advisory only: a "passed" test with a non-passing step (verdict is authored — 0016)
+    const bad = steps.find((s) => s?.status === "failed" || s?.status === "broken");
+    if (result?.status === "passed" && bad) {
+      diags.push(warn(Codes.STATUS_DISAGREES, loc, `test status "passed" but step "${bad.id}" is "${bad.status}"`));
+    }
+  }
+
+  if (!finalized) return diags;
+
+  // --- Full seal (status: finalized) ---
+
+  // (e) ended >= started
+  const started = input.run?.started;
+  const ended = input.run?.ended;
+  if (typeof started === "string" && typeof ended === "string") {
+    if (Date.parse(ended) < Date.parse(started)) {
+      diags.push(err(Codes.ENDED_BEFORE_STARTED, "run.yaml#/ended", `ended (${ended}) is before started (${started})`));
+    }
+  }
+
+  // (f) totals equals the rolled-up verdicts AND tests == sum of the four buckets
+  const rolled = rollup(input.tests);
+  const totals = input.run?.totals;
+  if (totals && typeof totals === "object") {
+    (["tests", "passed", "failed", "broken", "skipped"] as const).forEach((k) => {
+      if (totals[k] !== rolled[k]) {
+        diags.push(err(Codes.TOTALS_MISMATCH, `run.yaml#/totals/${k}`, `totals.${k} is ${totals[k]} but the rolled-up value is ${rolled[k]}`));
+      }
+    });
+    const bucketSum =
+      (totals.passed ?? 0) + (totals.failed ?? 0) + (totals.broken ?? 0) + (totals.skipped ?? 0);
+    if (totals.tests !== bucketSum) {
+      diags.push(err(Codes.TOTALS_MISMATCH, "run.yaml#/totals/tests", `totals.tests (${totals.tests}) does not equal the sum of the four buckets (${bucketSum})`));
+    }
+  }
+
+  // (g) every definition.sha256 present and hash-matches its file
+  for (const { testId, result } of input.tests) {
+    const loc = `tests/${testId}/result.yaml`;
+    const defPath = result?.definition?.path;
+    if (typeof defPath !== "string" || !isContained(defPath)) continue; // already flagged
+    const declared = result?.definition?.sha256;
+    if (typeof declared !== "string" || declared.length === 0) {
+      diags.push(err(Codes.HASH_MISSING, `${loc}#/definition/sha256`, "definition.sha256 is required on a finalized pack"));
+      continue;
+    }
+    const bytes = await input.container.readBytes(testId, defPath);
+    if (!bytes) continue; // missing file already flagged structure-only
+    const actual = `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+    if (actual !== declared) {
+      diags.push(err(Codes.HASH_MISMATCH, `${loc}#/definition/sha256`, `definition.sha256 ${declared} does not match the file hash ${actual}`));
+    }
+  }
+
+  return diags;
+}
+
+/** A path is contained iff it is relative, scheme-less, and never climbs out. */
+function isContained(relPath: string): boolean {
+  if (relPath.startsWith("/")) return false;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(relPath)) return false; // URL scheme
+  const norm = path.posix.normalize(relPath);
+  if (norm.startsWith("/") || norm === ".." || norm.startsWith("../")) return false;
+  return !norm.split("/").includes("..");
+}
+
+function rollup(tests: TestEntry[]): Totals {
+  const t: Totals = { tests: 0, passed: 0, failed: 0, broken: 0, skipped: 0 };
+  for (const { result } of tests) {
+    t.tests++;
+    const s = result?.status as Verdict | undefined;
+    if (s === "passed" || s === "failed" || s === "broken" || s === "skipped") t[s]++;
+  }
+  return t;
 }

--- a/src/validate/index.test.ts
+++ b/src/validate/index.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import * as path from "node:path";
+import { validate } from "./index";
+import { Codes } from "../contract";
+
+const FIX = path.resolve(__dirname, "../../fixtures");
+
+describe("validate — version gate & schema", () => {
+  it("rejects a 0.2 pack with version.unsupported and halts (no schema noise)", async () => {
+    const report = await validate(path.join(FIX, "invalid-L0/version-0.2.evidence"));
+    expect(report.valid).toBe(false);
+    const codes = report.diagnostics.map((d) => d.code);
+    expect(codes).toContain(Codes.VERSION_UNSUPPORTED);
+    expect(codes).not.toContain(Codes.SCHEMA); // halted before schema pass
+  });
+
+  it("flags a missing required field as a schema error (not a version error)", async () => {
+    const report = await validate(path.join(FIX, "invalid-L0/missing-status.evidence"));
+    expect(report.valid).toBe(false);
+    expect(report.diagnostics.some((d) => d.code === Codes.SCHEMA)).toBe(true);
+  });
+
+  it("reports MANIFEST_MISSING when there is no run.yaml", async () => {
+    const report = await validate(path.join(FIX, "valid-L0/smoke.evidence/tests"));
+    expect(report.valid).toBe(false);
+    expect(report.diagnostics.some((d) => d.code === Codes.MANIFEST_MISSING)).toBe(true);
+  });
+});

--- a/src/validate/index.ts
+++ b/src/validate/index.ts
@@ -1,0 +1,111 @@
+import { CONTRACT_VERSION, Codes, DEFAULT_PROFILE } from "../contract";
+import type { Diagnostic, ValidationReport } from "../contract";
+import { err } from "../diagnostics";
+import { openContainer } from "../pack/container";
+import { loadSchemas } from "../schemas/compile";
+import { parseYaml } from "../yaml";
+import { runCrossChecks } from "./checks";
+import type { ValidateFunction } from "ajv";
+
+export interface ValidateOptions {
+  profile?: string;
+}
+
+export async function validate(
+  target: string,
+  opts: ValidateOptions = {},
+): Promise<ValidationReport> {
+  const profile = opts.profile ?? DEFAULT_PROFILE;
+  const diagnostics: Diagnostic[] = [];
+  const finish = (): ValidationReport => ({
+    valid: !diagnostics.some((d) => d.severity === "error"),
+    profile,
+    version: CONTRACT_VERSION,
+    diagnostics,
+  });
+
+  const container = await openContainer(target);
+
+  const manifestRaw = await container.readManifest();
+  if (manifestRaw == null) {
+    diagnostics.push(
+      err(Codes.MANIFEST_MISSING, "run.yaml", "no top-level run.yaml — not a valid evidence pack"),
+    );
+    return finish();
+  }
+
+  let run: any;
+  try {
+    run = parseYaml(manifestRaw);
+  } catch (e: any) {
+    diagnostics.push(err(Codes.MANIFEST_PARSE, "run.yaml", `run.yaml is not valid YAML: ${e?.message ?? e}`));
+    return finish();
+  }
+
+  // Version gate (decision 0027): reject rather than mis-read; halt on mismatch.
+  const vg = versionGate(run, "run.yaml");
+  if (vg) {
+    diagnostics.push(vg);
+    return finish();
+  }
+
+  const schemas = loadSchemas(CONTRACT_VERSION, profile);
+  diagnostics.push(...schemaDiagnostics(schemas.run, run, "run.yaml"));
+
+  const testIds = await container.listTestIds();
+  const tests: { testId: string; result: any }[] = [];
+  for (const testId of testIds) {
+    const loc = `tests/${testId}/result.yaml`;
+    const raw = await container.readResult(testId);
+    if (raw == null) {
+      diagnostics.push(err(Codes.RESULT_MISSING, loc, `missing result.yaml for test "${testId}"`));
+      continue;
+    }
+    let result: any;
+    try {
+      result = parseYaml(raw);
+    } catch (e: any) {
+      diagnostics.push(err(Codes.RESULT_PARSE, loc, `result.yaml is not valid YAML: ${e?.message ?? e}`));
+      continue;
+    }
+    const rvg = versionGate(result, loc);
+    if (rvg) {
+      diagnostics.push(rvg);
+      continue; // skip this result's further checks
+    }
+    diagnostics.push(...schemaDiagnostics(schemas.result, result, loc));
+    tests.push({ testId, result });
+  }
+
+  diagnostics.push(...(await runCrossChecks({ run, tests, container })));
+
+  return finish();
+}
+
+function versionGate(obj: any, location: string): Diagnostic | null {
+  const v = obj?.evidence;
+  if (v === undefined || v === null) return null; // schema reports the required field
+  if (v !== CONTRACT_VERSION) {
+    return err(
+      Codes.VERSION_UNSUPPORTED,
+      location,
+      `pack declares evidence ${JSON.stringify(v)}; this validator implements ${CONTRACT_VERSION} — cannot validate`,
+    );
+  }
+  return null;
+}
+
+function schemaDiagnostics(
+  validateFn: ValidateFunction,
+  data: unknown,
+  location: string,
+): Diagnostic[] {
+  if (validateFn(data)) return [];
+  return (validateFn.errors ?? []).map((e) =>
+    err(
+      Codes.SCHEMA,
+      `${location}${e.instancePath || ""}`,
+      `${e.instancePath || "/"} ${e.message ?? "schema violation"}`,
+    ),
+  );
+}

--- a/src/yaml.test.ts
+++ b/src/yaml.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { parseYaml, parseDoc, stringifyDoc } from "./yaml";
+
+describe("yaml utilities", () => {
+  it("parses YAML to a plain object", () => {
+    expect(parseYaml("a: 1\nb: two\n")).toEqual({ a: 1, b: "two" });
+  });
+
+  it("round-trips, preserving comments and only changing the edited field", () => {
+    const src = "# top comment\nstatus: running\ntitle: keep me\n";
+    const doc = parseDoc(src);
+    doc.setIn(["status"], "finalized");
+    const out = stringifyDoc(doc);
+    expect(out).toContain("# top comment");
+    expect(out).toContain("title: keep me");
+    expect(out).toContain("status: finalized");
+    expect(out).not.toContain("status: running");
+  });
+});

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,0 +1,14 @@
+import { parse, parseDocument } from "yaml";
+import type { Document } from "yaml";
+
+export function parseYaml(raw: string): unknown {
+  return parse(raw);
+}
+
+export function parseDoc(raw: string): Document.Parsed {
+  return parseDocument(raw);
+}
+
+export function stringifyDoc(doc: Document.Parsed): string {
+  return doc.toString();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "lib": ["ES2022"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
## What this PR does

Lands the **L0 contract & design system** plus the first `src/` implementation of evidence-cli — the `validate` and `finalize` commands for contract version `0.1`, profile **L0**.

evidence-cli is an open, framework-agnostic format for what a test run produced: a `<name>.evidence` pack anchored by a top-level `run.yaml`, with per-test `result.yaml` and an opaque, framework-owned definition file.

## Design system (governance-first)

Per the repo rule *"the decision is the unit of work; code is downstream of it"*:

- **`design/contract/`** — L0 pack layout, lifecycle & verdicts, commands & config (prose).
- **`src/schemas/0.1/L0/`** — the `run.yaml` + `result.yaml` JSON Schemas, the single source of truth consumed by both the validator and the viewer (decision 0038 moved these out of `design/`, version-first).
- **`design/decisions/`** — ADRs 0001–0039 (proposition → options → decision → reasoning). New this branch:
  - **0037** — implementation stack & architecture (Ajv 2020 + ajv-formats, `yaml` round-trip, adm-zip, Commander, the Reporter seam, the version gate).
  - **0038** — schemas' canonical home is `src/schemas/<version>/<profile>/` (amends 0024/0025).
  - **0039** — `finalize` seals in place: the sealed file replaces the live directory.
- **`design/web/`** — the Vite/React viewer (repointed to the new schema location).
- **`fixtures/`** — `valid-L0/` + `invalid-L0/` + `finalize-L0/` conformance corpus.

## Implementation (`src/`, TypeScript)

- **`validate <dir|zip> --profile L0`** — version gate (rejects non-`0.1` rather than mis-reading, per 0027) → Ajv schema pass → status-gated cross-checks (0031): `result.test` vs dir name, `definition.path` containment + existence, ordinal uniqueness/monotonicity, and on finalized packs `ended ≥ started`, totals vs rolled-up verdicts, and definition hash matching. Exit `0`/`1`/`2`.
- **`finalize <dir>`** — derives totals + each `definition.sha256`, round-trips them back into the YAML (preserving producer formatting/comments), sets `finalized` + `ended`, and seals the directory in place into a flat `<name>.evidence` zip (0028/0035/0039). Directory-only.
- One **pack container** reads a directory and a flat zip identically; a **Reporter** seam gives TTY-aware human output, plain non-TTY output, and `--json` (the machine contract). Library functions are exposed for in-process mounting into kane-cli (0019).

## Testing

- **35 tests across 11 files**, all passing; `tsc --noEmit` clean.
- Driven by the fixtures corpus: the finalized smoke pack validates clean as both a directory and a sealed zip; each invalid fixture fails on its one specific check; a synthetic `0.2` pack yields a single `version.unsupported` with no schema noise; a `running` pack round-trips through `finalize` and then validates full-seal clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
