### PR TITLE
Public release flow: npm package (@testmuai/evidence-cli) + OSS community files

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/agent-bug-report.md
@@ -1,0 +1,25 @@
+---
+name: "Bug Report (Agent)"
+about: For AI agents to report bugs in evidence-cli
+title: "[Bug] "
+labels: bug, agent
+---
+
+**Version:** <!-- @testmuai/evidence-cli version -->
+
+**Usage:** <!-- library (import) / CLI / both -->
+
+**Profile:** <!-- L0 / L1 / n/a -->
+
+**Description:**
+<!-- What happened? -->
+
+**Steps to reproduce:**
+1.
+2.
+
+**Expected behavior:**
+<!-- What should have happened? -->
+
+**Output / diagnostics:**
+<!-- validator report (--json) or error output -->

--- a/.github/ISSUE_TEMPLATE/agent-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/agent-feature-request.md
@@ -1,0 +1,13 @@
+---
+name: "Feature Request (Agent)"
+about: For AI agents to suggest new features for evidence-cli
+title: "[Feature] "
+labels: enhancement, agent
+---
+
+**Description:**
+<!-- What feature would you like and why? Format, schema, or behavior changes
+start with a decision record — see CONTRIBUTING.md. -->
+
+**Use case:**
+<!-- What problem does this solve? -->

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug Report
+description: Report a bug in evidence-cli
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: evidence-cli version
+      description: "The @testmuai/evidence-cli version (from package.json, or `evidence --version`)."
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: usage
+    attributes:
+      label: How are you using it?
+      options:
+        - As a library (import)
+        - As the CLI (evidence …)
+        - Both
+    validations:
+      required: true
+
+  - type: dropdown
+    id: profile
+    attributes:
+      label: Profile
+      options:
+        - L0
+        - L1
+        - Not applicable
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug clearly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Additional details
+      description: Steps to reproduce, expected vs actual, and a minimal pack if you can share one.
+      placeholder: |
+        Steps to reproduce:
+        1. ...
+
+        Expected: ...
+        Actual: ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Output / diagnostics
+      description: Paste the validator report (`--json`) or the error output.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/LambdaTest/evidence-cli#readme
+    about: Read the README and the design/ living spec before filing an issue.
+  - name: Discord
+    url: https://discord.gg/kanQPEx9
+    about: Questions and discussion with the community.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,14 @@
+name: Feature Request
+description: Suggest a new feature for evidence-cli
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What would you like and why?
+      description: >
+        Describe the feature and the problem it solves. Note that format,
+        schema, or behavior changes start with a decision record — see
+        CONTRIBUTING.md.
+    validations:
+      required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+# Publishes @testmuai/evidence-cli to npm when a GitHub Release is published.
+# Requires the NPM_TOKEN repository secret (an npm automation token with publish
+# rights to the @testmuai scope). Nothing publishes until a Release is cut.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # npm provenance
+
+jobs:
+  publish:
+    name: build · test · publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify the release tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::release tag ($TAG) does not match package.json version ($PKG)"
+            exit 1
+          fi
+
+      - name: Build
+        run: npm run build
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: npm test
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/superpowers/
 
 # Local manual-testing playground (range server + remote-read demo). Not tracked.
 local-testing/
+local-testing*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to evidence-cli are documented here. This format follows
+[Keep a Changelog](https://keepachangelog.com/), and the project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [0.1.0] — Unreleased
+
+Initial public release of the `0.1` evidence contract.
+
+- **L0** — the minimal profile: the `.evidence` pack (`run.yaml` manifest anchor,
+  per-test `result.yaml`, and the opaque, framework-owned definition); `validate`
+  (status-gated conformance checking, directory or sealed zip) and `finalize`
+  (derive totals + definition hashes and seal, atomically, to a flat zip).
+- **L1** — the additive evidence-artifact profile: per-test execution logs and
+  step screenshots, and a global coverage directory (video optional).
+- **Range-addressable packs** — read only the entries you need from a sealed pack
+  on a blob store, without downloading the whole zip.
+- **Library + CLI** — `import { validate, finalize } from "@testmuai/evidence-cli"`,
+  or the `evidence` command.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at security@testmuai.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to evidence-cli
+
+Thank you for your interest in contributing! evidence-cli is an open,
+framework-agnostic format for what a test run produced. Contributions to the
+**format**, the **validator/CLI**, and the **docs** are all welcome.
+
+## The decision comes first
+
+evidence-cli is governed by a living decision log — **the decision is the unit of
+work, and code is downstream of it** (see [GOVERNANCE.md](GOVERNANCE.md)). Any
+change to behavior, schema, or contract starts as a decision record in
+[`design/decisions/`](design/decisions), and no code lands without one. This is
+what keeps the format trustworthy for the frameworks that adopt it.
+
+## What you can contribute
+
+- **Format & decisions** — propose or amend a decision (proposition → options →
+  decision → reasoning) under `design/decisions/`.
+- **Validator & CLI** — implementation in `src/`, written test-first.
+- **Conformance fixtures** — add a pack under `fixtures/` with an `expected.yaml`
+  sidecar; the conformance harness picks it up automatically.
+- **Docs** — the contract pages in `design/contract/`, the schemas, and this README.
+
+## How to contribute
+
+1. **Fork** the repository.
+2. **Create a branch** from `main` (`git checkout -b my-change`).
+3. For a behavior/schema/contract change, **add or amend a decision first**.
+4. **Make your changes test-first** — `npm test` green and `npx tsc --noEmit` clean.
+5. **Open a Pull Request** against `main`.
+
+## Guidelines
+
+- Keep changes focused — one PR per topic.
+- Every key in the format is `snake_case`.
+- Follow the existing style; keep commits focused and descriptive.
+- The conformance suite and the type check run in CI on every PR.
+
+## Reporting bugs & requesting features
+
+Use [GitHub Issues](https://github.com/LambdaTest/evidence-cli/issues/new/choose)
+to report bugs or request features. Both humans and AI agents are welcome to file
+issues.
+
+## Code of Conduct
+
+All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Security
+
+Please report vulnerabilities privately — see [SECURITY.md](SECURITY.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 LambdaTest Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,64 @@
-# evidence-cli
+# evidence-cli — TestMu AI (formerly LambdaTest)
 
-**An open, framework-agnostic format for what a test run produced — and the CLI
-that seals and validates it.**
+**An open, framework-agnostic format for what a test run produced — the
+`.evidence` pack, and the library + CLI that validate and seal it.**
 
-One shape, whatever made it: a browser agent, a Playwright suite, a Jest run, an
+[![npm version](https://img.shields.io/npm/v/@testmuai/evidence-cli)](https://www.npmjs.com/package/@testmuai/evidence-cli)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
+[![CI](https://github.com/LambdaTest/evidence-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/LambdaTest/evidence-cli/actions/workflows/ci.yml)
+![Node](https://img.shields.io/badge/node-%3E%3D18-brightgreen)
+[![Discord](https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/kanQPEx9)
+
+One shape, whatever made it — a browser agent, a Playwright suite, a Jest run, an
 API check. An evidence pack is readable by a CI dashboard, an auditor, or a human
 without knowing the framework that wrote it.
 
-```bash
-npm i -g evidence-cli
+## Install
 
-evidence finalize my-run.evidence/          # roll up totals, hash definitions, seal → .evidence (directory only)
-evidence index    my-run.evidence/          # (re)generate the optional human renders (summary.md / result.md)
-evidence validate my-run.evidence --profile L0   # check a directory OR a sealed .evidence zip
-evidence validate my-run.evidence --profile L1   # L1 = L0 + the captured-artifact layer (logs, screenshots, coverage)
+```bash
+# As a library (Node 18+)
+npm install @testmuai/evidence-cli
+
+# Or the CLI, globally
+npm install -g @testmuai/evidence-cli
 ```
+
+## Two ways to use it
+
+### As a library
+
+```ts
+import { validate, finalize } from "@testmuai/evidence-cli";
+
+// Validate a pack — a directory or a sealed .evidence zip — against a profile.
+const report = await validate("my-run.evidence", { profile: "L1" });
+if (!report.valid) {
+  for (const d of report.diagnostics) {
+    console.error(`${d.severity} ${d.location}: ${d.message} [${d.code}]`);
+  }
+}
+
+// Seal a live directory into a flat, range-addressable .evidence zip (atomically).
+const { totals, sealedPath } = await finalize("my-run.evidence", {
+  endedAt: new Date().toISOString(),
+});
+```
+
+The package ships type definitions; `validate` and `finalize` are the load-bearing
+entry points, and the pack container types (`openContainer`, `RemoteZipContainer`,
+…) are exported for reading packs directly — including ranged reads from a blob
+store.
+
+### As a CLI
+
+```bash
+evidence validate my-run.evidence --profile L0   # check a directory OR a sealed .evidence zip
+evidence validate my-run.evidence --profile L1   # L1 = L0 + the captured-artifact layer
+evidence finalize my-run.evidence/               # roll up totals, hash definitions, seal → .evidence
+```
+
+Exit codes: `0` valid · `1` invalid · `2` usage error. Add `--json` for a
+machine-readable report.
 
 ## What's in a pack
 
@@ -26,58 +70,55 @@ artifacts are load-bearing:
 <name>.evidence/
   run.yaml                 # required — manifest anchor (run identity, lifecycle, derived totals)
   tests/<id>/
-    <definition>           # required, OPAQUE — the framework's own artifact (kane test.md, *.spec.ts, …)
+    <definition>           # required, OPAQUE — the framework's own artifact (a Markdown spec, *.spec.ts, an API suite, …)
     result.yaml            # required — structured per-step outcomes
 ```
 
 evidence-cli knows **nothing** about any framework's definition format. It
 references and hashes the definition; it never parses it. The format scales by
-*adding* optional files and profiles (L1–L3, browser, mobile, a11y, security) —
-never by rewriting the L0 core.
+*adding* optional files and profiles — never by rewriting the L0 core.
+
+### Profiles — a ladder on one `0.1` contract
+
+- **L0** — the minimal, framework-neutral core (above).
+- **L1** — purely additive: keeps all of L0 and adds the captured **evidence
+  artifacts** (per-test execution logs and step screenshots, a global coverage
+  directory; video optional).
+
+Version and profile are different axes: a profile only *adds* requirements and
+never changes the version; only a breaking change to an existing meaning bumps
+`evidence` (`0.1` → `0.2`).
 
 ## This repo is its own spec
 
-`evidence-cli` is governed by a living decision log. The
-[`design/`](design) directory holds the **decisions** (proposition → options →
-decision → reasoning), the **contract**, and a **web viewer** that renders all of
-it. The **JSON Schemas** — the single source of truth, consumed by *both* the
-validator and the viewer — live under [`src/schemas/0.1/`](src/schemas) (decision
-0038).
+`evidence-cli` is governed by a living decision log. The [`design/`](design)
+directory holds the **decisions** (proposition → options → decision → reasoning),
+the **contract**, and a **web viewer** that renders all of it. The **JSON
+Schemas** — the single source of truth, consumed by *both* the validator and the
+viewer — live under [`src/schemas/0.1/`](src/schemas).
 
 > The decision is the unit of work. Code is downstream of it. No code lands
 > without a decision; no change lands without updating the structure.
 
-See [`GOVERNANCE.md`](GOVERNANCE.md).
+Browse it locally with `npm run docs`. See [`GOVERNANCE.md`](GOVERNANCE.md).
 
-## Browse the design locally
+## Support & contributing
 
-```bash
-npm run docs        # serves the design/ viewer at a local URL
-```
+- **Community:** [Join us on Discord](https://discord.gg/kanQPEx9) — questions,
+  discussion, and release announcements.
+- **Issues / bug reports:** [GitHub Issues](https://github.com/LambdaTest/evidence-cli/issues/new/choose)
+- **Contributing:** see [CONTRIBUTING.md](CONTRIBUTING.md) — every change starts
+  with a decision.
+- **Security:** see [SECURITY.md](SECURITY.md).
+- **Changelog:** [CHANGELOG.md](CHANGELOG.md).
 
-## Layout
+## 🚀 LambdaTest is now TestMu AI
 
-```
-evidence-cli/
-  design/
-    decisions/     # ADRs — every choice and its reasoning
-    contract/      # pack layout, lifecycle, commands (L0) + the L1 profile
-    profiles.yaml  # the additive profile ladder (L0 → L1 → …)
-    web/           # local viewer (Vite/React)
-  src/
-    schemas/0.1/   # JSON Schema — single source of truth, version-first (L0, L1)
-    …              # validate, finalize, index, profile/config resolution (TypeScript)
-  fixtures/0.1/    # conformance corpus, version- & profile-first (L0/{valid,invalid,finalized})
-```
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/),
+an autonomous Agentic AI Quality Engineering Platform. Same team, same
+infrastructure, same accounts — existing logins, scripts, and integrations
+continue to work. Find the new home at [testmuai.com](https://www.testmuai.com).
 
-Schemas live under `src/` (consumed directly by the validator, decision 0038);
-the viewer and contract render those same files — no second copy.
+## License
 
-## Status
-
-Early. The **`0.1` contract** is being defined, starting with its minimal
-**profile, L0**; richer profiles (L1–L3) follow on the *same* `0.1` contract.
-Version and profile are different axes: a profile only *adds* requirements and
-never changes the version, while a breaking change to an existing meaning bumps
-`evidence` to `0.2`. The contract and its reasoning are tracked in
-[`design/decisions/`](design/decisions) (see decision 0027).
+[Apache-2.0](LICENSE) © LambdaTest Inc.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | Yes       |
+
+## Reporting a Vulnerability
+
+**Do not file security issues as public GitHub issues.**
+
+Instead, email **security@testmuai.com** with:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Impact assessment (if known)
+- Your contact information
+
+## Scope
+
+This policy covers:
+
+- The `evidence-cli` library and its CLI (`validate`, `finalize`)
+- Reading and sealing `.evidence` packs — path containment, zip handling, and
+  ranged reads over remote blobs
+- The JSON Schemas and the validation logic
+
+Thank you for helping keep evidence-cli safe.

--- a/package.json
+++ b/package.json
@@ -1,15 +1,53 @@
 {
-  "name": "evidence-cli",
-  "version": "0.0.0",
-  "description": "An open, framework-agnostic format for what a test run produced — and the CLI that seals and validates it.",
-  "license": "MIT",
-  "private": true,
-  "bin": { "evidence": "dist/cli.js" },
+  "name": "@testmuai/evidence-cli",
+  "version": "0.1.0",
+  "description": "An open, framework-agnostic format for what a test run produced — the .evidence pack, and the library + CLI that validate and seal it.",
+  "license": "Apache-2.0",
+  "author": "TestMu AI (formerly LambdaTest)",
+  "homepage": "https://github.com/LambdaTest/evidence-cli#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LambdaTest/evidence-cli.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LambdaTest/evidence-cli/issues"
+  },
+  "keywords": [
+    "evidence",
+    "test-results",
+    "test-report",
+    "conformance",
+    "json-schema",
+    "validation",
+    "ci",
+    "test-automation",
+    "framework-agnostic"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "bin": {
+    "evidence": "dist/cli.js"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
-    "build": "tsc && node scripts/copy-schemas.mjs",
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-schemas.mjs",
+    "prepack": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "docs": "npm --prefix design/web run dev",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name("evidence")
   .description("Validate and finalize .evidence packs")
-  .version("0.0.0");
+  .version("0.1.0");
 
 program
   .command("validate")

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/conformance/**"]
+}


### PR DESCRIPTION
## What this PR does

Makes evidence-cli **publishable and importable**, and adds the standard
organization community-health files (Apache-2.0). No behavior/contract changes.

### Packaging & release

- **`package.json`** is now publishable: name **`@testmuai/evidence-cli`**,
  license **Apache-2.0**, version **0.1.0**, an `exports` map with type
  definitions, `files: ["dist"]`, `engines.node >= 18`, `publishConfig` (public +
  provenance), a `prepack` build, and `repository`/`homepage`/`bugs`/`keywords` +
  an updated description.
- **`tsconfig.build.json`** emits the library only — the published tarball is 55
  files (no test files, no conformance harness); `tsc --noEmit` still typechecks
  everything.
- **`.github/workflows/release.yml`**: on a published GitHub Release →
  build → typecheck → test → `npm publish` with provenance and a tag/version
  guard. Requires an `NPM_TOKEN` secret. **Nothing publishes until a Release is
  cut.**
- CLI `--version` now reports `0.1.0`.

Consumers can then:

```ts
import { validate, finalize } from "@testmuai/evidence-cli";
```

or install the `evidence` CLI globally.

### Community health files

- **LICENSE** (Apache-2.0), **CODE_OF_CONDUCT.md** (Contributor Covenant,
  contact `security@testmuai.com`).
- **SECURITY.md** and **CONTRIBUTING.md** adapted to evidence-cli — contributions
  are decision-gated (every change starts with a decision record, per
  `GOVERNANCE.md`).
- **CHANGELOG.md**; **`.github/ISSUE_TEMPLATE/`** (bug/feature forms + agent
  variants + config).
- **README** reworked: badges, install, a **library-import** example and CLI
  usage, the L0→L1 profile ladder, and support/contributing/license sections —
  kept host-agnostic.

### Verification

- 86 tests pass; `tsc --noEmit` clean; `npm pack --dry-run` confirms a clean
  55-file tarball; a `require("dist")` smoke resolves `validate`/`finalize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
