### PR TITLE
fix(release): publish public package from private repo (drop npm provenance)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,11 @@
 name: Release
 
 # Publishes @testmuai/evidence-cli to npm when a GitHub Release is published.
-# Requires the NPM_TOKEN repository secret (an npm automation token with publish
-# rights to the @testmuai scope). Nothing publishes until a Release is cut.
+# The package is public (publishConfig.access) even though this source repo is
+# private; npm provenance is intentionally NOT used, since it requires a public
+# source repository. Requires the NPM_TOKEN repository secret (an npm automation
+# token with publish rights to the @testmuai scope). Nothing publishes until a
+# Release is cut.
 
 on:
   release:
@@ -10,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write # npm provenance
 
 jobs:
   publish:

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/copy-schemas.mjs",


### PR DESCRIPTION
## What this fixes

The `v0.1.0` release job succeeded through build, typecheck, test, and auth, then failed at `npm publish`:

```
npm error code E422
422 Unprocessable Entity — Error verifying sigstore provenance bundle:
Unsupported GitHub Actions source repository visibility: "private".
Only public source repositories are supported when publishing with provenance.
```

npm **provenance** (sigstore attestation) only works when the **source repo is public**. This repo is private, so provenance can't be produced — but the npm package is public regardless (that's `publishConfig.access`, independent of repo visibility). Provenance was the only thing requiring a public repo.

## Change

- Remove `publishConfig.provenance` (keep `access: public`) — publishes a **public package from this private repo**.
- Drop the now-unneeded `id-token: write` workflow permission; document the intent in the workflow header.

No other change. `npm publish --dry-run` confirms: *"Publishing … with tag latest and public access"*, no provenance signing.

## Re-release

The package never published (registry returns 404 for `@testmuai/evidence-cli`), so **`0.1.0` is unused**. After this merges, re-cut the release on the updated `main` (delete & recreate the `v0.1.0` release/tag, or tag a fresh `v0.1.1`) and the workflow will publish cleanly.

Provenance can be re-enabled later if the repo is ever made public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
