### PR TITLE
feat(failure): triage.severity enum + failure-index lift (0.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to evidence-cli are documented here. This format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.1.6] — Unreleased
+
+- **Failure `severity`** — a record's `triage` block MAY carry a closed-enum
+  `severity` (`critical|major|minor|cosmetic`); `finalize` lifts it verbatim
+  into the run-level failure index row. Purely additive.
+
 ## [0.1.5] — 2026-07-08
 
 - **Merge** — `evidence merge` combines N packs under a declarative merge-rules

--- a/src/finalize/index.test.ts
+++ b/src/finalize/index.test.ts
@@ -154,6 +154,29 @@ describe("finalize failure index (decision 0044)", () => {
     expect(idx.failures.map((r: any) => r.step)).toEqual(["open", "pay", "refund"]);
   });
 
+  it("lifts triage.severity verbatim; omits it when absent", async () => {
+    const dir = await stageCopy();
+    const steps = path.join(dir, "tests", "checkout", "steps");
+    await fs.mkdir(path.join(steps, "1-open"), { recursive: true });
+    await fs.mkdir(path.join(steps, "2-pay"), { recursive: true });
+    await fs.writeFile(
+      path.join(steps, "1-open", "failure.yaml"),
+      "step: open\nstatus: broken\nerror: { message: boom }\ntriage: { status: triaged, severity: major }\n",
+    );
+    // a record without severity produces a row with no severity key
+    await fs.writeFile(
+      path.join(steps, "2-pay", "failure.yaml"),
+      "step: pay\nstatus: failed\nerror: { message: timeout }\ntriage: { status: triaged }\n",
+    );
+
+    await finalize(dir, { endedAt: "2026-06-28T09:00:30Z" });
+    const idx = parseYaml(await readSealed(dir, "failure.yaml")) as any;
+
+    expect(idx.failures[0].severity).toBe("major");
+    expect(idx.failures[0].triage_status).toBe("triaged");
+    expect("severity" in idx.failures[1]).toBe(false);
+  });
+
   it("fails fast on a step record that is not valid YAML", async () => {
     const dir = await stageCopy();
     const folder = path.join(dir, "tests", "checkout", "steps", "2-pay");

--- a/src/finalize/index.ts
+++ b/src/finalize/index.ts
@@ -15,6 +15,7 @@ interface FailureRow {
   path: string;
   title?: string;
   triage_status?: string;
+  severity?: string;
 }
 
 export interface FinalizeOptions {
@@ -162,6 +163,8 @@ async function collectFailureRows(testsDir: string, id: string): Promise<Failure
     if (typeof rec?.title === "string" && rec.title.length > 0) row.title = rec.title;
     const ts = rec?.triage?.status;
     if (typeof ts === "string" && ts.length > 0) row.triage_status = ts;
+    const sev = rec?.triage?.severity;
+    if (typeof sev === "string" && sev.length > 0) row.severity = sev;
     rows.push(row);
   }
   return rows;

--- a/src/schemas/0.1/L1/failure-index.schema.json
+++ b/src/schemas/0.1/L1/failure-index.schema.json
@@ -43,6 +43,10 @@
             "description": "Lifted verbatim from the record's title when present.",
             "type": "string",
             "minLength": 1
+          },
+          "severity": {
+            "description": "Lifted verbatim from the record's triage.severity when present.",
+            "enum": ["critical", "major", "minor", "cosmetic"]
           }
         },
         "additionalProperties": true

--- a/src/schemas/0.1/L1/failure.schema.json
+++ b/src/schemas/0.1/L1/failure.schema.json
@@ -94,6 +94,10 @@
           "description": "Triage lifecycle — closed enum (snake_case, decision 0036).",
           "enum": ["untriaged", "triaged", "in_progress", "dismissed"]
         },
+        "severity": {
+          "description": "Investigation-assessed defect severity — closed enum. Lifted into the failure-index row by finalize.",
+          "enum": ["critical", "major", "minor", "cosmetic"]
+        },
         "by": {
           "description": "Who/what triaged. `kind` and `id` are open strings; `at` is required when the block is present.",
           "type": "object",


### PR DESCRIPTION
## What

A step-level failure record's `triage` block MAY carry a closed-enum `severity` — `critical | major | minor | cosmetic` — and `finalize` lifts it verbatim into the run-level failure index row, alongside `title`/`triage_status`.

## Why

The evidence viewer's Issues tab renders severity pills (P0/P1/P2 palette) from the one-read pack-root index.

## Changes

- `schemas/0.1/L1/failure.schema.json` — optional `triage.severity` enum
- `schemas/0.1/L1/failure-index.schema.json` — optional lifted `severity` on rows
- `finalize` — lifts `triage.severity` verbatim (same pattern as `title`)
- CHANGELOG 0.1.6 entry

Purely additive: records without severity index exactly as before. Suite: 178/178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)