### PR TITLE
feat(merge): identity grouping — nest supersessions, split distinct tests (0046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to evidence-cli are documented here. This format follows
 [Keep a Changelog](https://keepachangelog.com/), and the project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.1.7] — 2026-07-20
+
+- **Merge identity grouping** — an optional `tests.identity` block in
+  merge-rules turns a test-id collision from "pick one winner" into "group by
+  identity". `keys` (dot-paths into `result.yaml`, the caller's vocabulary) decide
+  sameness; `on_same: nest` keeps every copy — the latest run holds the canonical
+  `tests/<id>/` and superseded runs are archived beneath it as `1/`, `2/` …
+  oldest first — while `on_different: split` gives a distinct test its own
+  sibling `tests/<id>-1/`. Guard rules still resolve first, so a
+  `must: same` + `error` rule can never be downgraded into a split. Nested
+  copies are inert to totals, the failure index and validation.
+  `MergeReport` collisions gain optional `action`/`folder`. Purely additive —
+  absent the block, merge behaves exactly as before. See decision 0046.
+
+## [0.1.6] — 2026-07-19
+
+- **Windows seal reliability** — `finalize` retries transient lock errors
+  (`EPERM`/`EACCES`/`EBUSY`) around the atomic seal, with `.tmp` removal
+  retries and a ~15s seal-rename budget, so a scanner or indexer holding a
+  handle no longer fails the seal.
+
 ## [0.1.5] — 2026-07-08
 
 - **Merge** — `evidence merge` combines N packs under a declarative merge-rules

--- a/design/contract/03-commands.md
+++ b/design/contract/03-commands.md
@@ -186,6 +186,12 @@ packs:
   on_ineligible: abort          # abort | skip
 tests:
   on_collision: error           # error | prefer_first | prefer_latest | discard
+  identity:                     # OPTIONAL (0046); absent → 0045 behaviour, unchanged
+    keys:                       # dot-paths into result.yaml — the caller's vocabulary
+      - external_id.commit_id
+      - external_id.test_id
+    on_same: nest               # nest | prefer_latest | prefer_first | error
+    on_different: split         # split | error
 rules:
   - file: run.yaml              # scope: compared ACROSS all eligible packs
     key: environment.producer.name
@@ -275,6 +281,36 @@ copies. Folding collisions into `attempts[]` (retry semantics) is
 deliberately out of scope — see decision
 [0033 — attempts is a per-attempt outcome list](#/decisions).
 
+### Identity grouping (optional, 0046)
+
+When `tests.identity` is configured, a collision that violates **no**
+`result.yaml` rule is resolved by **grouping** instead of by picking a winner —
+guard rules still abort first, so a `must: same` + `error` rule can never be
+downgraded into a split. Two copies have the same identity when **every** key
+in `keys` compares equal under the canonical deep equality above (absent ==
+absent counts as same). The challenger is matched against each existing group
+of that id **in allocation order**; the first match absorbs it (`on_same`), and
+no match allocates a new folder (`on_different`).
+
+| Action | Meaning |
+| --- | --- |
+| `on_same: nest` | keep **every** copy: the latest run takes the canonical `tests/<id>/`, each superseded run is archived whole beneath it as `1/`, `2/` … oldest first (by `ended`, fallback `started`; ties → CLI order) |
+| `on_different: split` | the copy lands in a **new sibling** `tests/<id>-1/`, `-2/` … the first group keeps the unsuffixed name |
+
+Suffixes are allocated against the union of every eligible pack's test ids, so
+a split never steals a name some pack legitimately owns — if `<id>-1` exists as
+a real test, the split takes `<id>-2`. A split folder's `result.yaml` `test`
+field is **rewritten** to equal its directory (the L0 cross-check requires the
+equality); a nested copy keeps its original id, since nothing validates it and
+the archive stays truthful. `discard` tombstones the **base id** — every group
+of it goes, split siblings included.
+
+Nested copies are **inert**: totals walk only top-level `tests/*`, the failure
+index reads only `tests/<id>/steps/`, and the L1 step checks enumerate only
+`<test>/steps/`. An archive therefore changes no count and fails no check. Note
+that `nest` retains artifacts `prefer_latest` would discard, so a merged pack
+grows with the number of runs kept.
+
 ### `run.yaml` — per-key disposition
 
 | Key | Across the N inputs | Value in merged `run.yaml` |
@@ -313,11 +349,20 @@ packs:
   eligible: [shard-a, shard-b]              # run_ids, CLI order
   skipped:  [{ run_id: shard-a2, rule: "run.yaml run_id must different", reason: duplicate of shard-a }]
 tests:
-  merged: 214
-  collisions: [{ test: checkout, winner: shard-b, rule: tests.on_collision=prefer_latest }]
+  merged: 214                               # TOP-LEVEL test folders (= groups)
+  collisions:
+    - { test: checkout, winner: shard-b, rule: tests.on_collision=prefer_latest }
+    # 0046 outcomes carry the shape they took and where the copy landed:
+    - { test: login, winner: shard-c, rule: tests.identity.on_same=nest, action: nest, folder: login }
+    - { test: login, winner: shard-d, rule: tests.identity.on_different=split, action: split, folder: login-1 }
   discarded: [flaky-login]
 output: { path: merged.evidence, run_id: nightly-2026-07-08, finalized: true }
 ```
+
+`action` and `folder` appear only on 0046's shape-changing outcomes; the other
+three fields are unconditional, so existing `--json` consumers keep parsing
+unchanged. `winner` is the canonical member for `nest` and the absorbed
+challenger for `split`.
 
 Policy-sanctioned skips/discards exit `0` — the report carries the story. The
 pack itself stays clean: `merged_from` is the only in-pack trace of the

--- a/design/decisions/0046-collision-identity-grouping.md
+++ b/design/decisions/0046-collision-identity-grouping.md
@@ -117,6 +117,13 @@ decision: >
   run_id for `nest` and the absorbed challenger's for `split`. Merge remains
   DETERMINISTIC — every ordering derives from pack metadata and CLI order,
   no clock and no randomness are read.
+governs:
+  - design/contract/03-commands.md
+  - src/schemas/merge-rules.schema.json
+  - src/merge
+feature: [merge]
+depends_on: [45, 44, 43, 40, 33, 31]
+supersedes: []
 ---
 
 ## Reasoning

--- a/design/decisions/0046-collision-identity-grouping.md
+++ b/design/decisions/0046-collision-identity-grouping.md
@@ -1,0 +1,193 @@
+---
+id: 46
+slug: collision-identity-grouping
+title: Collision identity grouping — nest supersessions, split distinct tests
+status: accepted
+date: 2026-07-20
+proposition: >
+  0045 resolves a test-id collision to exactly ONE surviving copy and lists
+  "cross-environment matrix identity (keeping both copies of a colliding test
+  disambiguated by environment)" as deferred. Two copies of `tests/<id>/` can
+  mean two different things: the SAME logical test run twice, or two GENUINELY
+  DIFFERENT tests that happen to share a derived id. How does a caller declare
+  which is which, and what shape does the merged pack take in each case?
+options:
+  - id: identity-block
+    summary: >
+      An optional `tests.identity: {keys, on_same, on_different}` block names
+      the key paths that constitute test identity and the outcome for each
+      case. Collisions become GROUPS keyed by identity: same identity nests
+      superseded copies under the canonical folder, different identity splits
+      into a suffixed sibling folder. Absent the block, 0045's behaviour is
+      unchanged.
+    chosen: true
+  - id: split-action-in-rules
+    summary: >
+      No new block — add a `split` action to the existing result.yaml
+      `on_violation` enum and a `nest` action to `tests.on_collision`, so
+      identity is whatever set of rules happens to carry `split`.
+    chosen: false
+  - id: caller-side-pregrouping
+    summary: >
+      Leave merge alone. The caller inspects packs, computes identity groups
+      itself, pre-renames colliding test directories in staging copies, and
+      merges a set that no longer collides.
+    chosen: false
+decision: >
+  `tests.identity` is an OPTIONAL block in merge-rules.yaml:
+  `{keys: [<dot-path>...], on_same: <action>, on_different: <action>}`. When
+  it is ABSENT, merge behaves EXACTLY as 0045 specifies — this decision is
+  purely additive and changes no default. `keys` is a non-empty array of
+  dot-paths into the parsed `result.yaml`, resolved by the same `getKey`
+  walker and compared by the same canonical `deepEqual` as 0045's generic
+  rules, inheriting its absent-key semantics VERBATIM: absent == absent
+  counts as SAME, absent-vs-present counts as DIFFERENT. Two copies have the
+  SAME IDENTITY when every listed key compares equal. `keys` are the
+  CALLER'S FACT — evidence-cli never interprets them and ships no default
+  set, so a producer's identity vocabulary (a TMS test uuid, a commit sha, a
+  browser name) stays in the producer's policy file and the tool stays
+  vendor-neutral.
+  RESOLUTION ORDER on a collision is fixed and does NOT change 0045's first
+  stage: the `result.yaml` rules run FIRST, in file order, pairwise against
+  the FIRST GROUP's representative, and the first violated rule applies its
+  `on_violation` exactly as today; only when no rule is violated does the
+  identity block run. A guard rule (`must: same` + `on_violation: error`)
+  therefore still ABORTS ahead of any grouping and can never be quietly
+  downgraded into a split folder — the property that lets a caller keep
+  tenancy guards and identity keys in one file without their precedence
+  being ambiguous. With no identity block and no rule violated, the default
+  `tests.on_collision` applies, unchanged. A GROUP'S REPRESENTATIVE is its
+  FIRST MEMBER IN CLI ORDER — the group's original claimant — so stage one
+  preserves 0045's incumbent semantics exactly, and stage two's comparison is
+  well-defined because every member of a group shares an identity by
+  construction. `discard` TOMBSTONES THE BASE ID, not a folder: every group of
+  that base id is dropped, INCLUDING split siblings already allocated, and the
+  id stays tombstoned against later packs — a split folder is not a way around
+  a tombstone.
+  The union walk generalises from ONE INCUMBENT per test id to an ORDERED
+  LIST OF GROUPS per test id. A group is `{baseId, folder, members[]}`:
+  `baseId` is the original `tests/<id>` name, `folder` is the output
+  directory name, `members` are the eligible packs contributing a copy, in
+  CLI order. A challenger is compared against each existing group of its
+  baseId IN ALLOCATION ORDER; the FIRST group whose representative has the
+  same identity ABSORBS it (`on_same`); if no group matches, `on_different`
+  applies. This is what makes 3+-way collisions well-defined — pack C's copy
+  is tested against the `<id>` group AND the `<id>-1` group before a third
+  folder is minted — and it is why identity is a DECLARED SET of keys rather
+  than an emergent property of the rule list: the walk needs the set as an
+  up-front fact. The single-member group where `folder == baseId` is
+  precisely 0045's behaviour, so there is ONE code path, not two.
+  `on_same` takes `nest | prefer_latest | prefer_first | error`;
+  `on_different` takes `split | error`. `nest` KEEPS EVERY MEMBER: members
+  sort ASCENDING by the source pack's `run.yaml` `ended` (fallback
+  `started`, ties broken by CLI order), the LAST — the latest run — occupies
+  the canonical `tests/<folder>/` exactly as an uncontested test does, and
+  each earlier member is written WHOLE to `tests/<folder>/<n>/`, 1-based,
+  `1/` being the OLDEST. WHOLE-TREE ATOMICITY (0045) is preserved per
+  member: a member's `result.yaml`, definition, `logs/`, `steps/` and video
+  travel together and nothing is mixed between copies. `split` allocates a
+  NEW SIBLING folder: the first group of a baseId keeps the UNSUFFIXED name,
+  later groups take `<baseId>-1`, `<baseId>-2`, and so on. Suffixes are
+  allocated against a RESERVATION SET — the union of every eligible pack's
+  test ids, computed once before the walk (the eligible set is already fixed
+  by then) — and a candidate name already in that set or already allocated
+  is SKIPPED, so a split never steals a name some pack legitimately owns.
+  A split folder's `result.yaml` `test` field is REWRITTEN to equal its new
+  directory name, because 0031's validator cross-check requires that
+  equality; the rewrite goes through the comment-preserving
+  `parseDoc`/`setIn` path 0045 already uses for the environment push-down, so
+  the definition file is never touched and hash checks stay green. A NESTED
+  member's `result.yaml` `test` field is NOT rewritten: nothing validates a
+  nested copy, and preserving the original id keeps the archive truthful
+  about what it was. 0043's environment push-down runs on EVERY copy
+  written, canonical and nested alike, each against ITS OWN source pack's
+  environment — the divergent keys are what let an archived copy be read
+  standalone, which is the entire reason for keeping it.
+  NESTED COPIES ARE INERT to every derived artifact, by construction rather
+  than by special-casing: finalize's totals walk only top-level `tests/*`
+  directories, its failure index reads only `tests/<id>/steps/`, and the L1
+  step checks enumerate only `<test>/steps/`. A numbered subdirectory is
+  therefore invisible to totals, to the root failure index, to
+  `listTestIds`, and to validation — it rides along as an archive and
+  changes no count. `MergeReport.tests.merged` counts TOP-LEVEL test
+  folders, which is now the number of GROUPS. `MergeReport.tests.collisions`
+  gains two OPTIONAL fields, `action` (`nest` | `split`) and `folder` (the
+  output directory), leaving `{test, winner, rule}` intact so existing
+  `--json` consumers keep parsing; `winner` carries the canonical member's
+  run_id for `nest` and the absorbed challenger's for `split`. Merge remains
+  DETERMINISTIC — every ordering derives from pack metadata and CLI order,
+  no clock and no randomness are read.
+---
+
+## Reasoning
+
+**Why an identity block rather than a `split` action in the rule list.** The
+rule list is a sequence of INDEPENDENT pairwise predicates: each one fires on
+its own and the first violation decides. That shape is exactly right for
+"which copy wins", where the answer is a choice between two things already in
+hand. It is wrong for grouping, because grouping needs to ask a question the
+rule list cannot express — *does this challenger belong to group 0, group 1,
+or neither?* — and answering it requires knowing the WHOLE SET of keys that
+constitute identity before any comparison happens. Scraping that set back out
+of a flat list as "every rule whose action is `split`" would make identity an
+emergent property of an unrelated ordering: adding a tenancy guard would
+silently redefine what "the same test" means. Declaring the set once, in a
+block that exists to declare it, keeps the fact where a reader looks for it.
+
+**Why the new actions are not enum values on `on_collision`.** `error`,
+`prefer_first`, `prefer_latest` and `discard` all answer one question — which
+of two copies survives — and none of them changes the SHAPE of the merged
+pack; the output is always `tests/<id>/`, one directory per colliding id.
+`nest` and `split` answer a different question: what topology does the output
+take. Keeping them in the identity block, where the condition that selects
+them also lives, states that difference in the format instead of hiding it
+behind a wider enum whose members no longer share a meaning.
+
+**Why the caller cannot do this outside merge.** Merge DISCARDS the losing
+tree, so by the time a caller could post-process, the superseded artifacts are
+gone. The only caller-side alternative is to pre-group: read every pack, apply
+identity comparison, rename directories in staging copies, then merge a
+non-colliding set. That reimplements pack reading, dot-path resolution and
+canonical equality in a second place, and it puts the rename — including the
+0031 `test`-field rewrite — outside the tool that owns the contract those
+rules come from.
+
+**Why the latest run keeps the canonical slot.** The alternative — nesting
+every member uniformly under `tests/<id>/1..n/` — is more symmetric, but it
+would move `result.yaml` out of `tests/<id>/result.yaml` and break the L0
+layout for every consumer, requiring contract changes to validate, finalize
+and every reader. Keeping the latest run exactly where an uncontested test
+sits means a consumer that does not care about history reads a nested pack
+identically to a flat one, and the archive is strictly additive.
+
+## Consequences
+
+- `src/merge/collide.ts` is reshaped: `claims` becomes
+  `Map<baseId, TestGroup[]>`, the exported `UnionEntry` is replaced by
+  `TestGroup {baseId, folder, members[]}`, and the reservation set is computed
+  from the eligible packs before the walk.
+- `src/merge/assemble.ts` takes `groups: TestGroup[]` in place of
+  `union: UnionEntry[]`, sorts each group's members chronologically, writes the
+  canonical and nested copies, and rewrites `test` on split folders only.
+- `src/merge/rules.ts` gains the `IdentityPolicy` type; `DEFAULT_RULES` is
+  UNCHANGED (`tests.identity` stays undefined), so the strict defaults of 0045
+  still hold when `--rules` is omitted.
+- `src/schemas/merge-rules.schema.json` gains `tests.identity` with
+  `additionalProperties: false`, `keys` as a `minItems: 1` array of non-empty
+  strings, and the two action enums.
+- `contract.ts`'s `MergeReport.tests.collisions` gains optional `action` and
+  `folder`; `src/report/reporter.ts` prints the nest/split outcome.
+- `design/contract/03-commands.md` gains the identity block in the `merge`
+  section — the rules-file shape, the resolution order, and the two output
+  layouts.
+- A `nest` merge produces a LARGER pack than the same merge under
+  `prefer_latest`: artifacts that are discarded today are retained. This is
+  the intent of the feature, not a regression, but it is a real change to
+  output size for callers who opt in.
+- Deferred, additively: identity keys addressing `run.yaml` (today's `keys`
+  are result-scoped, matching where per-test identity lives); a `fold_attempts`
+  action folding nested members into 0033's `attempts[]` (still deferred from
+  0045, and now expressible as a third `on_same` action); an
+  auto-derived identity from the environment block, which 0045 sketched as
+  "cross-environment matrix identity" — the explicit `keys` list subsumes it
+  for now, since a caller can name the environment paths directly.

--- a/design/decisions/0046-collision-identity-grouping.md
+++ b/design/decisions/0046-collision-identity-grouping.md
@@ -44,7 +44,7 @@ decision: >
   counts as SAME, absent-vs-present counts as DIFFERENT. Two copies have the
   SAME IDENTITY when every listed key compares equal. `keys` are the
   CALLER'S FACT — evidence-cli never interprets them and ships no default
-  set, so a producer's identity vocabulary (a TMS test uuid, a commit sha, a
+  set, so a producer's identity vocabulary (a test-manager id, a commit sha, a
   browser name) stays in the producer's policy file and the tool stays
   vendor-neutral.
   RESOLUTION ORDER on a collision is fixed and does NOT change 0045's first

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testmuai/evidence-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "An open, framework-agnostic format for what a test run produced — the .evidence pack, and the library + CLI that validate and seal it.",
   "license": "Apache-2.0",
   "author": "TestMu AI (formerly LambdaTest)",

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -44,7 +44,10 @@ export interface MergeReport {
   };
   tests: {
     merged: number;
-    collisions: { test: string; winner: string; rule: string }[];
+    // `action`/`folder` are present only for 0046's shape-changing outcomes;
+    // the three original fields are unconditional, so existing --json
+    // consumers keep parsing unchanged.
+    collisions: { test: string; winner: string; rule: string; action?: "nest" | "split"; folder?: string }[];
     discarded: string[];
   };
   output: { path: string; runId: string; finalized: boolean };

--- a/src/design-links.test.ts
+++ b/src/design-links.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { parseYaml } from "./yaml";
+
+/**
+ * The design viewer (design/web) is generated from this metadata, not from the
+ * prose: `governs` is reverse-indexed into the "shaped by" chips on the spec
+ * page, and `feature` attaches a decision to its spec-area node. A decision
+ * that omits them still renders in the decisions log but silently disappears
+ * from every other view — which is invisible until someone goes looking.
+ */
+const DECISIONS_DIR = path.join(__dirname, "..", "design", "decisions");
+
+async function decisionFiles(): Promise<string[]> {
+  const entries = await fs.readdir(DECISIONS_DIR);
+  return entries.filter((f) => /^\d{4}-.*\.md$/.test(f)).sort();
+}
+
+async function frontmatterOf(file: string): Promise<any> {
+  const raw = await fs.readFile(path.join(DECISIONS_DIR, file), "utf8");
+  const m = raw.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) throw new Error(`${file}: no frontmatter block`);
+  return parseYaml(m[1]);
+}
+
+describe("decision frontmatter", () => {
+  it("every decision declares what it governs and which feature it belongs to", async () => {
+    const missing: string[] = [];
+    for (const file of await decisionFiles()) {
+      const fm = await frontmatterOf(file);
+      const governs = Array.isArray(fm?.governs) ? fm.governs : [];
+      const feature = Array.isArray(fm?.feature) ? fm.feature : [];
+      if (governs.length === 0) missing.push(`${file}: governs`);
+      if (feature.length === 0) missing.push(`${file}: feature`);
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("every governed PATH still exists in the repo", async () => {
+    const repoRoot = path.join(__dirname, "..");
+    const broken: string[] = [];
+    for (const file of await decisionFiles()) {
+      const fm = await frontmatterOf(file);
+      for (const g of Array.isArray(fm?.governs) ? fm.governs : []) {
+        if (typeof g !== "string") continue;
+        // A governs entry may be a conceptual AREA ("repo") rather than a path
+        // — only path-shaped entries are checkable against the filesystem.
+        if (!g.includes("/")) continue;
+        const target = g.split("#")[0]; // a JSON-pointer suffix addresses a key, not a file
+        await fs.access(path.join(repoRoot, target)).catch(() => {
+          broken.push(`${file}: ${target}`);
+        });
+      }
+    }
+    expect(broken).toEqual([]);
+  });
+});

--- a/src/merge/assemble.test.ts
+++ b/src/merge/assemble.test.ts
@@ -10,7 +10,7 @@ import { stagePack, sealCopy } from "./testkit";
 import { parseYaml } from "../yaml";
 import { validate } from "../validate";
 
-async function stagePair(): Promise<{ out: string; eligible: any[]; union: any[] }> {
+async function stagePair(): Promise<{ out: string; eligible: any[]; groups: any[] }> {
   const a = await sealCopy(
     await stagePack({
       runId: "a",
@@ -33,15 +33,101 @@ async function stagePair(): Promise<{ out: string; eligible: any[]; union: any[]
     }),
   );
   const { eligible } = await gatePacks([a, b], DEFAULT_RULES);
-  const { union } = await resolveCollisions(eligible, DEFAULT_RULES);
+  const { groups } = await resolveCollisions(eligible, DEFAULT_RULES);
   const out = path.join(await fs.mkdtemp(path.join(os.tmpdir(), "evi-asm-")), "m.evidence");
-  return { out, eligible, union };
+  return { out, eligible, groups };
 }
+
+const IDENTITY_RULES: any = {
+  ...DEFAULT_RULES,
+  tests: {
+    on_collision: "error",
+    identity: { keys: ["external_id.commit_id"], on_same: "nest", on_different: "split" },
+  },
+};
+
+/** Stage N packs that all claim `login`, resolve them under the identity policy. */
+async function stageGrouped(specs: any[]): Promise<{ out: string; eligible: any[]; groups: any[] }> {
+  const paths: string[] = [];
+  for (const s of specs) paths.push(await sealCopy(await stagePack({ l1: true, ...s })));
+  const { eligible } = await gatePacks(paths, IDENTITY_RULES);
+  const { groups } = await resolveCollisions(eligible, IDENTITY_RULES);
+  const out = path.join(await fs.mkdtemp(path.join(os.tmpdir(), "evi-asm-")), "m.evidence");
+  return { out, eligible, groups };
+}
+
+const readResult = async (out: string, rel: string): Promise<any> =>
+  parseYaml(await fs.readFile(path.join(out, "tests", rel, "result.yaml"), "utf8"));
+
+describe("assemble — identity grouping (0046)", () => {
+  it("keeps the latest member canonical and nests superseded ones oldest-first", async () => {
+    // CLI order deliberately differs from chronological order
+    const { out, eligible, groups } = await stageGrouped([
+      { runId: "b", ended: "2026-07-08T10:00:00Z", tests: { login: { externalId: { commit_id: "abc", session_id: "s-b" } } } },
+      { runId: "a", ended: "2026-07-08T09:00:00Z", tests: { login: { externalId: { commit_id: "abc", session_id: "s-a" } } } },
+      { runId: "c", ended: "2026-07-08T11:00:00Z", tests: { login: { externalId: { commit_id: "abc", session_id: "s-c" } } } },
+    ]);
+    await assemble(out, { runId: "nightly" }, eligible, groups);
+
+    expect((await readResult(out, "login")).external_id.session_id).toBe("s-c"); // latest
+    expect((await readResult(out, "login/1")).external_id.session_id).toBe("s-a"); // oldest
+    expect((await readResult(out, "login/2")).external_id.session_id).toBe("s-b");
+    // nested copies carry their whole tree
+    await fs.access(path.join(out, "tests/login/1/test.md"));
+    await fs.access(path.join(out, "tests/login/1/logs/console.ndjson"));
+    await fs.access(path.join(out, "tests/login/1/steps/2-pay/screenshot.png"));
+  });
+
+  it("rewrites test: in a split folder, leaves it untouched in a nested copy", async () => {
+    const { out, eligible, groups } = await stageGrouped([
+      { runId: "a", ended: "2026-07-08T09:00:00Z", tests: { login: { externalId: { commit_id: "abc" } } } },
+      { runId: "b", ended: "2026-07-08T10:00:00Z", tests: { login: { externalId: { commit_id: "abc" } } } },
+      { runId: "c", ended: "2026-07-08T11:00:00Z", tests: { login: { externalId: { commit_id: "zzz" } } } },
+    ]);
+    await assemble(out, { runId: "nightly" }, eligible, groups);
+
+    expect((await readResult(out, "login")).test).toBe("login");
+    expect((await readResult(out, "login/1")).test).toBe("login"); // archive stays truthful
+    expect((await readResult(out, "login-1")).test).toBe("login-1"); // must equal its directory
+  });
+
+  it("pushes divergent environment down into nested copies from their own source", async () => {
+    const { out, eligible, groups } = await stageGrouped([
+      {
+        runId: "a",
+        ended: "2026-07-08T09:00:00Z",
+        environment: { producer: { name: "kane" }, ci: { shard: "1" } },
+        tests: { login: { externalId: { commit_id: "abc" } } },
+      },
+      {
+        runId: "b",
+        ended: "2026-07-08T10:00:00Z",
+        environment: { producer: { name: "kane" }, ci: { shard: "2" } },
+        tests: { login: { externalId: { commit_id: "abc" } } },
+      },
+    ]);
+    await assemble(out, { runId: "nightly" }, eligible, groups);
+
+    expect((await readResult(out, "login")).environment.ci).toEqual({ shard: "2" }); // canonical = pack b
+    expect((await readResult(out, "login/1")).environment.ci).toEqual({ shard: "1" }); // nested = pack a
+  });
+
+  it("a pack with nested and split folders validates clean at L0", async () => {
+    const { out, eligible, groups } = await stageGrouped([
+      { runId: "a", ended: "2026-07-08T09:00:00Z", tests: { login: { externalId: { commit_id: "abc" } } } },
+      { runId: "b", ended: "2026-07-08T10:00:00Z", tests: { login: { externalId: { commit_id: "abc" } } } },
+      { runId: "c", ended: "2026-07-08T11:00:00Z", tests: { login: { externalId: { commit_id: "zzz" } } } },
+    ]);
+    await assemble(out, { runId: "nightly" }, eligible, groups);
+    const report = await validate(out, { profile: "L0" });
+    expect(report.valid).toBe(true);
+  });
+});
 
 describe("assemble", () => {
   it("synthesizes run.yaml, pushes divergent env down, namespaces coverage/metrics, copies whole trees", async () => {
-    const { out, eligible, union } = await stagePair();
-    await assemble(out, { runId: "nightly" }, eligible, union);
+    const { out, eligible, groups } = await stagePair();
+    await assemble(out, { runId: "nightly" }, eligible, groups);
 
     const run = parseYaml(await fs.readFile(path.join(out, "run.yaml"), "utf8")) as any;
     expect(run).toMatchObject({ evidence: "0.1", run_id: "nightly", status: "running", title: "t-a" });
@@ -70,22 +156,22 @@ describe("assemble", () => {
   });
 
   it("the assembled pack validates clean at L0 while running", async () => {
-    const { out, eligible, union } = await stagePair();
-    await assemble(out, { runId: "nightly" }, eligible, union);
+    const { out, eligible, groups } = await stagePair();
+    await assemble(out, { runId: "nightly" }, eligible, groups);
     const report = await validate(out, { profile: "L0" });
     expect(report.valid).toBe(true);
     expect(report.status).toBe("running");
   });
 
   it("refuses to overwrite an existing output path (USAGE)", async () => {
-    const { out, eligible, union } = await stagePair();
+    const { out, eligible, groups } = await stagePair();
     await fs.mkdir(out, { recursive: true });
-    await expect(assemble(out, { runId: "nightly" }, eligible, union)).rejects.toMatchObject({ code: "USAGE" });
+    await expect(assemble(out, { runId: "nightly" }, eligible, groups)).rejects.toMatchObject({ code: "USAGE" });
   });
 
   it("--title overrides the first pack's title", async () => {
-    const { out, eligible, union } = await stagePair();
-    await assemble(out, { runId: "nightly", title: "Nightly regression" }, eligible, union);
+    const { out, eligible, groups } = await stagePair();
+    await assemble(out, { runId: "nightly", title: "Nightly regression" }, eligible, groups);
     const run = parseYaml(await fs.readFile(path.join(out, "run.yaml"), "utf8")) as any;
     expect(run.title).toBe("Nightly regression");
   });

--- a/src/merge/assemble.ts
+++ b/src/merge/assemble.ts
@@ -4,7 +4,8 @@ import { CONTRACT_VERSION } from "../contract";
 import type { PackContainer } from "../pack/container";
 import { parseDoc, parseYaml, stringifyDoc, stringifyYaml } from "../yaml";
 import type { EligiblePack } from "./gates";
-import type { UnionEntry } from "./collide";
+import { orderMembers } from "./collide";
+import type { TestGroup } from "./collide";
 import { deepEqual, getKey } from "./rules";
 
 export interface AssembleOptions {
@@ -22,7 +23,7 @@ export async function assemble(
   outDir: string,
   opts: AssembleOptions,
   eligible: EligiblePack[],
-  union: UnionEntry[],
+  groups: TestGroup[],
 ): Promise<void> {
   try {
     await fs.access(outDir);
@@ -34,9 +35,33 @@ export async function assemble(
   }
   await fs.mkdir(outDir, { recursive: true });
 
-  // Winners' whole trees + per-source coverage nesting.
-  for (const entry of union) {
-    await copyTree(entry.source.container, `tests/${entry.testId}`, path.join(outDir, "tests", entry.testId));
+  // Each group's members, whole-tree: the latest run takes the canonical
+  // tests/<folder>/ exactly as an uncontested test does, and every superseded
+  // member is archived beneath it as 1/, 2/ … oldest first (decision 0046).
+  // `written` is the per-copy record the environment push-down works from.
+  const written: { pack: EligiblePack; resultPath: string }[] = [];
+  for (const group of groups) {
+    const ordered = orderMembers(group.members);
+    const canonical = ordered[ordered.length - 1];
+    const groupDir = path.join(outDir, "tests", group.folder);
+    await copyTree(canonical.container, `tests/${group.baseId}`, groupDir);
+    written.push({ pack: canonical, resultPath: path.join(groupDir, "result.yaml") });
+
+    for (let i = 0; i < ordered.length - 1; i++) {
+      const nestedDir = path.join(groupDir, String(i + 1));
+      await copyTree(ordered[i].container, `tests/${group.baseId}`, nestedDir);
+      written.push({ pack: ordered[i], resultPath: path.join(nestedDir, "result.yaml") });
+    }
+
+    // A split folder must satisfy 0031's test-id/directory equality. A NESTED
+    // copy is not validated and keeps its original id — the archive stays
+    // truthful about what it was.
+    if (group.folder !== group.baseId) {
+      await editResult(path.join(groupDir, "result.yaml"), (doc) => {
+        doc.set("test", group.folder);
+        return true;
+      });
+    }
   }
   for (const pack of eligible) {
     if (await pack.container.isDir("coverage")) {
@@ -54,21 +79,22 @@ export async function assemble(
     if (envs.every((e) => key in e && deepEqual(e[key], first))) commonEnv[key] = first;
     else divergent.add(key);
   }
-  for (const entry of union) {
-    const sourceEnv = entry.source.run?.environment ?? {};
+  // Applied to EVERY copy written, canonical and nested alike, each against
+  // its own source pack — the divergent keys are what let an archived copy be
+  // read standalone, which is the reason for keeping it at all.
+  for (const { pack, resultPath } of written) {
+    const sourceEnv = pack.run?.environment ?? {};
     const pushable = [...divergent].filter((k) => k in sourceEnv);
     if (pushable.length === 0) continue;
-    const resultPath = path.join(outDir, "tests", entry.testId, "result.yaml");
-    const raw = await fs.readFile(resultPath, "utf8");
-    const parsed = parseYaml(raw);
-    const doc = parseDoc(raw);
-    let dirty = false;
-    for (const key of pushable) {
-      if (getKey(parsed, `environment.${key}`) !== undefined) continue; // per-test value wins
-      doc.setIn(["environment", key], sourceEnv[key]);
-      dirty = true;
-    }
-    if (dirty) await fs.writeFile(resultPath, stringifyDoc(doc), "utf8");
+    await editResult(resultPath, (doc, parsed) => {
+      let dirty = false;
+      for (const key of pushable) {
+        if (getKey(parsed, `environment.${key}`) !== undefined) continue; // per-test value wins
+        doc.setIn(["environment", key], sourceEnv[key]);
+        dirty = true;
+      }
+      return dirty;
+    });
   }
 
   // Metrics: namespaced by flattening into the name — <label>/<name> — so the
@@ -96,6 +122,17 @@ export async function assemble(
   if (Object.keys(metrics).length > 0) run.metrics = metrics;
   if (Object.keys(commonEnv).length > 0) run.environment = commonEnv;
   await fs.writeFile(path.join(outDir, "run.yaml"), stringifyYaml(run), "utf8");
+}
+
+/**
+ * Edit a copied result.yaml through the comment-preserving document path, so
+ * the definition file is never touched and hash checks stay green. The mutator
+ * returns whether it changed anything; false skips the write entirely.
+ */
+async function editResult(resultPath: string, mutate: (doc: any, parsed: unknown) => boolean): Promise<void> {
+  const raw = await fs.readFile(resultPath, "utf8");
+  const doc = parseDoc(raw);
+  if (mutate(doc, parseYaml(raw))) await fs.writeFile(resultPath, stringifyDoc(doc), "utf8");
 }
 
 /** Recursively copy a container subtree (dir or zip source) to the filesystem. */

--- a/src/merge/collide.test.ts
+++ b/src/merge/collide.test.ts
@@ -14,11 +14,13 @@ async function eligibleOf(...specs: any[]): Promise<EligiblePack[]> {
 
 const rulesWith = (tests: any, keyRules: any[] = []): MergeRules => ({ ...DEFAULT_RULES, tests, rules: keyRules });
 
+const IDENTITY = { keys: ["external_id.commit_id", "external_id.test_id"], on_same: "nest", on_different: "split" };
+
 describe("resolveCollisions", () => {
   it("disjoint sets union; default collision errors", async () => {
     const e = await eligibleOf({ runId: "a", tests: { login: {} } }, { runId: "b", tests: { checkout: {} } });
     const r = await resolveCollisions(e, DEFAULT_RULES);
-    expect(r.union.map((u) => u.testId).sort()).toEqual(["checkout", "login"]);
+    expect(r.groups.map((g) => g.folder).sort()).toEqual(["checkout", "login"]);
     expect(r.collisions).toEqual([]);
     expect(r.discarded).toEqual([]);
 
@@ -31,9 +33,9 @@ describe("resolveCollisions", () => {
       { runId: "a", ended: "2026-07-08T09:00:00Z", tests: { checkout: {} } },
       { runId: "b", ended: "2026-07-08T10:00:00Z", tests: { checkout: {} } },
     );
-    expect((await resolveCollisions(e, rulesWith({ on_collision: "prefer_first" }))).union[0].source.run.run_id).toBe("a");
+    expect((await resolveCollisions(e, rulesWith({ on_collision: "prefer_first" }))).groups[0].members[0].run.run_id).toBe("a");
     const latest = await resolveCollisions(e, rulesWith({ on_collision: "prefer_latest" }));
-    expect(latest.union[0].source.run.run_id).toBe("b");
+    expect(latest.groups[0].members[0].run.run_id).toBe("b");
     expect(latest.collisions[0]).toMatchObject({ test: "checkout", winner: "b", rule: "tests.on_collision=prefer_latest" });
   });
 
@@ -43,7 +45,7 @@ describe("resolveCollisions", () => {
       { runId: "b", ended: "2026-07-08T09:00:00Z", tests: { checkout: {} } },
     );
     const r = await resolveCollisions(e, rulesWith({ on_collision: "prefer_latest" }));
-    expect(r.union[0].source.run.run_id).toBe("a");
+    expect(r.groups[0].members[0].run.run_id).toBe("a");
   });
 
   it("discard tombstones across a 3rd pack", async () => {
@@ -53,7 +55,7 @@ describe("resolveCollisions", () => {
       { runId: "c", tests: { checkout: {} } },
     );
     const r = await resolveCollisions(e, rulesWith({ on_collision: "discard" }));
-    expect(r.union).toHaveLength(0);
+    expect(r.groups).toHaveLength(0);
     expect(r.discarded).toEqual(["checkout"]);
   });
 
@@ -67,8 +69,112 @@ describe("resolveCollisions", () => {
       e,
       rulesWith({ on_collision: "error" }, [{ file: "result.yaml", key: "status", must: "same", on_violation: "prefer_latest" }]),
     );
-    expect(r.union[0].source.run.run_id).toBe("b");
+    expect(r.groups[0].members[0].run.run_id).toBe("b");
     expect(r.collisions[0].rule).toBe("result.yaml status must same");
+  });
+
+  it("same identity nests superseded members under the canonical folder", async () => {
+    const e = await eligibleOf(
+      { runId: "a", ended: "2026-07-08T09:00:00Z", tests: { checkout: { externalId: { commit_id: "abc", test_id: "T1" } } } },
+      { runId: "b", ended: "2026-07-08T10:00:00Z", tests: { checkout: { externalId: { commit_id: "abc", test_id: "T1" } } } },
+    );
+    const r = await resolveCollisions(e, rulesWith({ on_collision: "error", identity: IDENTITY }));
+    expect(r.groups).toHaveLength(1);
+    expect(r.groups[0].folder).toBe("checkout");
+    expect(r.groups[0].members.map((m) => m.run.run_id)).toEqual(["a", "b"]);
+    expect(r.collisions[0]).toMatchObject({
+      test: "checkout",
+      winner: "b",
+      action: "nest",
+      folder: "checkout",
+      rule: "tests.identity.on_same=nest",
+    });
+  });
+
+  it("different identity splits into a suffixed sibling folder", async () => {
+    const e = await eligibleOf(
+      { runId: "a", tests: { checkout: { externalId: { commit_id: "abc", test_id: "T1" } } } },
+      { runId: "b", tests: { checkout: { externalId: { commit_id: "def", test_id: "T9" } } } },
+    );
+    const r = await resolveCollisions(e, rulesWith({ on_collision: "error", identity: IDENTITY }));
+    expect(r.groups.map((g) => g.folder)).toEqual(["checkout", "checkout-1"]);
+    expect(r.groups[1].baseId).toBe("checkout");
+    expect(r.groups[1].members.map((m) => m.run.run_id)).toEqual(["b"]);
+    expect(r.collisions[0]).toMatchObject({
+      test: "checkout",
+      winner: "b",
+      action: "split",
+      folder: "checkout-1",
+      rule: "tests.identity.on_different=split",
+    });
+  });
+
+  it("a third copy joins the group it matches, in allocation order", async () => {
+    const e = await eligibleOf(
+      { runId: "a", ended: "2026-07-08T09:00:00Z", tests: { checkout: { externalId: { commit_id: "abc", test_id: "T1" } } } },
+      { runId: "b", ended: "2026-07-08T10:00:00Z", tests: { checkout: { externalId: { commit_id: "def", test_id: "T9" } } } },
+      { runId: "c", ended: "2026-07-08T11:00:00Z", tests: { checkout: { externalId: { commit_id: "def", test_id: "T9" } } } },
+    );
+    const r = await resolveCollisions(e, rulesWith({ on_collision: "error", identity: IDENTITY }));
+    // c matches group 1 (checkout-1), not group 0 — no third folder is minted
+    expect(r.groups.map((g) => g.folder)).toEqual(["checkout", "checkout-1"]);
+    expect(r.groups[0].members.map((m) => m.run.run_id)).toEqual(["a"]);
+    expect(r.groups[1].members.map((m) => m.run.run_id)).toEqual(["b", "c"]);
+  });
+
+  it("a split never steals a test id some pack legitimately owns", async () => {
+    const e = await eligibleOf(
+      { runId: "a", tests: { checkout: { externalId: { commit_id: "abc" } } } },
+      { runId: "b", tests: { checkout: { externalId: { commit_id: "def" } }, "checkout-1": {} } },
+    );
+    const r = await resolveCollisions(e, rulesWith({ on_collision: "error", identity: IDENTITY }));
+    // "checkout-1" is a real test in pack b, so the split skips to -2
+    expect(r.groups.map((g) => g.folder).sort()).toEqual(["checkout", "checkout-1", "checkout-2"]);
+    expect(r.groups.find((g) => g.folder === "checkout-2")?.baseId).toBe("checkout");
+    expect(r.groups.find((g) => g.folder === "checkout-1")?.baseId).toBe("checkout-1");
+  });
+
+  it("absent identity keys on both sides count as the same test", async () => {
+    const e = await eligibleOf(
+      { runId: "a", ended: "2026-07-08T09:00:00Z", tests: { checkout: {} } },
+      { runId: "b", ended: "2026-07-08T10:00:00Z", tests: { checkout: {} } },
+    );
+    const r = await resolveCollisions(e, rulesWith({ on_collision: "error", identity: IDENTITY }));
+    expect(r.groups).toHaveLength(1);
+    expect(r.groups[0].members.map((m) => m.run.run_id)).toEqual(["a", "b"]);
+  });
+
+  it("a guard rule aborts ahead of the identity block", async () => {
+    const e = await eligibleOf(
+      { runId: "a", tests: { checkout: { externalId: { commit_id: "abc", org_id: "o1" } } } },
+      { runId: "b", tests: { checkout: { externalId: { commit_id: "def", org_id: "o2" } } } },
+    );
+    // identity alone would split; the org guard must fire first
+    await expect(
+      resolveCollisions(
+        e,
+        rulesWith({ on_collision: "error", identity: IDENTITY }, [
+          { file: "result.yaml", key: "external_id.org_id", must: "same", on_violation: "error" },
+        ]),
+      ),
+    ).rejects.toMatchObject({ code: "ABORT" });
+  });
+
+  it("discard tombstones the base id, dropping split siblings too", async () => {
+    const e = await eligibleOf(
+      { runId: "a", tests: { checkout: { externalId: { commit_id: "abc" } } } },
+      { runId: "b", tests: { checkout: { externalId: { commit_id: "def" } } } },
+      { runId: "c", tests: { checkout: { status: "failed", externalId: { commit_id: "ghi" } } } },
+    );
+    // a vs b split into checkout / checkout-1; c's differing status then discards the whole base id
+    const r = await resolveCollisions(
+      e,
+      rulesWith({ on_collision: "error", identity: IDENTITY }, [
+        { file: "result.yaml", key: "status", must: "same", on_violation: "discard" },
+      ]),
+    );
+    expect(r.groups).toHaveLength(0);
+    expect(r.discarded).toEqual(["checkout"]);
   });
 
   it("a non-violated key rule falls through to the default", async () => {
@@ -81,7 +187,7 @@ describe("resolveCollisions", () => {
       e,
       rulesWith({ on_collision: "prefer_first" }, [{ file: "result.yaml", key: "status", must: "same", on_violation: "discard" }]),
     );
-    expect(r.union[0].source.run.run_id).toBe("a");
+    expect(r.groups[0].members[0].run.run_id).toBe("a");
     expect(r.collisions[0].rule).toBe("tests.on_collision=prefer_first");
   });
 });

--- a/src/merge/collide.ts
+++ b/src/merge/collide.ts
@@ -1,18 +1,30 @@
 import { parseYaml } from "../yaml";
 import { abortErr } from "./gates";
 import type { EligiblePack } from "./gates";
-import { getKey, violates } from "./rules";
+import { deepEqual, getKey, violates } from "./rules";
 import type { CollisionAction, MergeRules } from "./rules";
 
-export interface UnionEntry {
-  testId: string;
-  source: EligiblePack;
+/** What a collision resolves to: 0045's four actions plus 0046's two shapes. */
+type ResolvedAction = CollisionAction | "nest" | "split";
+
+/**
+ * One output test directory. `baseId` is the id claimed in the source packs;
+ * `folder` is where it lands in the merged pack (they differ only when a split
+ * allocates a suffixed sibling). `members` are the packs contributing a copy,
+ * in CLI order — more than one only when a policy keeps them all.
+ */
+export interface TestGroup {
+  baseId: string;
+  folder: string;
+  members: EligiblePack[];
 }
 
 export interface CollisionRecord {
   test: string;
   winner: string; // run_id of the surviving copy ("" when discarded)
   rule: string; // the deciding rule, e.g. "result.yaml status must same" or "tests.on_collision=prefer_latest"
+  action?: "nest" | "split"; // present only for 0046's shape-changing outcomes
+  folder?: string; // the output directory the copy landed in
 }
 
 /**
@@ -26,46 +38,101 @@ export interface CollisionRecord {
 export async function resolveCollisions(
   eligible: EligiblePack[],
   rules: MergeRules,
-): Promise<{ union: UnionEntry[]; collisions: CollisionRecord[]; discarded: string[] }> {
-  const claims = new Map<string, UnionEntry>();
+): Promise<{ groups: TestGroup[]; collisions: CollisionRecord[]; discarded: string[] }> {
+  const claims = new Map<string, TestGroup[]>();
   const tombstoned = new Set<string>();
   const collisions: CollisionRecord[] = [];
+
+  // Suffix reservation: no split may take a name some pack legitimately owns.
+  // The eligible set is already fixed here, so this is computable up front.
+  const reserved = new Set<string>();
+  for (const pack of eligible) for (const id of await pack.container.listTestIds()) reserved.add(id);
+  const allocated = new Set<string>();
+  const nextFreeName = (baseId: string): string => {
+    for (let i = 1; ; i++) {
+      const name = `${baseId}-${i}`;
+      if (!reserved.has(name) && !allocated.has(name)) return name;
+    }
+  };
 
   for (const pack of eligible) {
     for (const testId of await pack.container.listTestIds()) {
       if (tombstoned.has(testId)) continue; // discarded for good
-      const incumbent = claims.get(testId);
-      if (!incumbent) {
-        claims.set(testId, { testId, source: pack });
+      const groups = claims.get(testId);
+      if (!groups) {
+        claims.set(testId, [{ baseId: testId, folder: testId, members: [pack] }]);
+        allocated.add(testId);
         continue;
       }
+      const incumbent = groups[0];
 
-      const [a, b] = await Promise.all([readResult(incumbent.source, testId), readResult(pack, testId)]);
-      let action: CollisionAction = rules.tests.on_collision;
+      const [a, b] = await Promise.all([readResult(representative(incumbent), testId), readResult(pack, testId)]);
+      let action: ResolvedAction = rules.tests.on_collision;
       let ruleLabel = `tests.on_collision=${action}`;
+      let ruleFired = false;
       for (const rule of rules.rules) {
         if (rule.file !== "result.yaml") continue;
         if (violates(rule.must, getKey(a, rule.key), getKey(b, rule.key))) {
           action = rule.on_violation as CollisionAction;
           ruleLabel = `result.yaml ${rule.key} must ${rule.must}`;
+          ruleFired = true;
           break;
         }
       }
 
+      // Stage two (0046): only when no rule fired, so a guard rule still
+      // aborts ahead of any grouping and can never become a split folder.
+      // The challenger is matched against every group of this base id, in
+      // allocation order — that is what makes a 3+-way collision well-defined.
+      const identity = rules.tests.identity;
+      let target = incumbent;
+      if (!ruleFired && identity) {
+        let match: TestGroup | undefined;
+        for (const group of groups) {
+          const rep = await readResult(representative(group), group.baseId);
+          if (identity.keys.every((k) => deepEqual(getKey(rep, k), getKey(b, k)))) {
+            match = group;
+            break;
+          }
+        }
+        action = match ? identity.on_same : identity.on_different;
+        ruleLabel = match ? `tests.identity.on_same=${action}` : `tests.identity.on_different=${action}`;
+        if (match) target = match;
+      }
+
       switch (action) {
         case "error":
-          throw abortErr(`test "${testId}" collides between packs "${incumbent.source.run.run_id}" and "${pack.run.run_id}" [${ruleLabel}]`);
+          throw abortErr(
+            `test "${testId}" collides between packs "${representative(target).run.run_id}" and "${pack.run.run_id}" [${ruleLabel}]`,
+          );
         case "prefer_first":
-          collisions.push({ test: testId, winner: incumbent.source.run.run_id, rule: ruleLabel });
+          collisions.push({ test: testId, winner: representative(target).run.run_id, rule: ruleLabel });
           break;
         case "prefer_latest": {
-          const winner = laterOf(incumbent.source, pack) === pack ? pack : incumbent.source;
-          if (winner === pack) claims.set(testId, { testId, source: pack });
+          const winner = laterOf(representative(target), pack) === pack ? pack : representative(target);
+          if (winner === pack) target.members = [pack];
           collisions.push({ test: testId, winner: winner.run.run_id, rule: ruleLabel });
           break;
         }
+        case "nest":
+          target.members.push(pack);
+          collisions.push({
+            test: testId,
+            winner: latestOf(target.members).run.run_id,
+            rule: ruleLabel,
+            action: "nest",
+            folder: target.folder,
+          });
+          break;
+        case "split": {
+          const folder = nextFreeName(testId);
+          allocated.add(folder);
+          groups.push({ baseId: testId, folder, members: [pack] });
+          collisions.push({ test: testId, winner: pack.run.run_id, rule: ruleLabel, action: "split", folder });
+          break;
+        }
         case "discard":
-          claims.delete(testId);
+          claims.delete(testId); // tombstones the BASE ID — split siblings go too
           tombstoned.add(testId);
           collisions.push({ test: testId, winner: "", rule: ruleLabel });
           break;
@@ -73,7 +140,34 @@ export async function resolveCollisions(
     }
   }
 
-  return { union: [...claims.values()], collisions, discarded: [...tombstoned].sort() };
+  return { groups: [...claims.values()].flat(), collisions, discarded: [...tombstoned].sort() };
+}
+
+/**
+ * Members oldest-first by run end (fallback start). Array#sort is stable and
+ * `members` arrive in CLI order, so ties keep CLI order — the tie-break 0045
+ * already pins for prefer_latest.
+ */
+export function orderMembers(members: EligiblePack[]): EligiblePack[] {
+  return [...members].sort((x, y) => stampOf(x) - stampOf(y));
+}
+
+/** The member whose run ended latest — the copy that takes the canonical slot. */
+export function latestOf(members: EligiblePack[]): EligiblePack {
+  const ordered = orderMembers(members);
+  return ordered[ordered.length - 1];
+}
+
+/** A pack's position in time: `ended` when present, else `started`. */
+function stampOf(p: EligiblePack): number {
+  const v = typeof p.run?.ended === "string" ? p.run.ended : p.run?.started;
+  const t = typeof v === "string" ? Date.parse(v) : NaN;
+  return Number.isNaN(t) ? -Infinity : t;
+}
+
+/** A group's representative: its first member in CLI order — the original claimant. */
+function representative(group: TestGroup): EligiblePack {
+  return group.members[0];
 }
 
 async function readResult(pack: EligiblePack, testId: string): Promise<any> {
@@ -88,10 +182,5 @@ async function readResult(pack: EligiblePack, testId: string): Promise<any> {
 
 /** The pack whose run ended later (fallback started); ties keep the incumbent. */
 function laterOf(incumbent: EligiblePack, challenger: EligiblePack): EligiblePack {
-  const stamp = (p: EligiblePack): number => {
-    const v = typeof p.run?.ended === "string" ? p.run.ended : p.run?.started;
-    const t = typeof v === "string" ? Date.parse(v) : NaN;
-    return Number.isNaN(t) ? -Infinity : t;
-  };
-  return stamp(challenger) > stamp(incumbent) ? challenger : incumbent;
+  return stampOf(challenger) > stampOf(incumbent) ? challenger : incumbent;
 }

--- a/src/merge/index.test.ts
+++ b/src/merge/index.test.ts
@@ -58,6 +58,46 @@ describe("merge()", () => {
     expect(v.status).toBe("running");
   });
 
+  it("identity rules nest supersessions and split distinct tests, end to end", async () => {
+    const ex = (commit: string) => ({ externalId: { commit_id: commit, test_id: "T1" } });
+    const a = await sealCopy(
+      await stagePack({ runId: "a", ended: "2026-07-08T09:00:00Z", l1: true, tests: { checkout: ex("abc") } }),
+    );
+    const b = await sealCopy(
+      await stagePack({ runId: "b", ended: "2026-07-08T10:00:00Z", l1: true, tests: { checkout: ex("abc") } }),
+    );
+    const c = await sealCopy(
+      await stagePack({ runId: "c", ended: "2026-07-08T11:00:00Z", l1: true, tests: { checkout: ex("zzz") } }),
+    );
+    const out = await outPath();
+    const report = await merge([a, b, c], {
+      runId: "nightly",
+      out,
+      finalize: true,
+      rulesPath: await writeRules(
+        "tests:\n  on_collision: error\n  identity:\n    keys: [external_id.commit_id, external_id.test_id]\n    on_same: nest\n    on_different: split\n",
+      ),
+    });
+
+    // two top-level tests: the nested group and the split sibling
+    expect(report.tests.merged).toBe(2);
+    expect(report.tests.collisions).toEqual([
+      { test: "checkout", winner: "b", rule: "tests.identity.on_same=nest", action: "nest", folder: "checkout" },
+      { test: "checkout", winner: "c", rule: "tests.identity.on_different=split", action: "split", folder: "checkout-1" },
+    ]);
+
+    const zip = new AdmZip(out);
+    const entry = (p: string) => zip.getEntry(p)?.getData().toString("utf8");
+    // the archive rode into the seal, and totals counted only the two top-level tests
+    expect(entry("tests/checkout/1/result.yaml")).toContain("test: checkout");
+    expect(entry("tests/checkout-1/result.yaml")).toContain("test: checkout-1");
+    const run = parseYaml(entry("run.yaml")!) as any;
+    expect(run.totals).toEqual({ tests: 2, passed: 2, failed: 0, broken: 0, skipped: 0 });
+
+    const v = await validate(out, { profile: "L1" });
+    expect(v.valid).toBe(true);
+  });
+
   it("propagates USAGE for a bad rules file before opening packs", async () => {
     const out = await outPath();
     await expect(

--- a/src/merge/index.ts
+++ b/src/merge/index.ts
@@ -27,8 +27,8 @@ export interface MergeOptions {
 export async function merge(inputs: string[], opts: MergeOptions): Promise<MergeReport> {
   const rules = await loadRules(opts.rulesPath); // USAGE errors fire before any pack opens
   const { eligible, skipped } = await gatePacks(inputs, rules);
-  const { union, collisions, discarded } = await resolveCollisions(eligible, rules);
-  await assemble(opts.out, { runId: opts.runId, title: opts.title }, eligible, union);
+  const { groups, collisions, discarded } = await resolveCollisions(eligible, rules);
+  await assemble(opts.out, { runId: opts.runId, title: opts.title }, eligible, groups);
 
   let finalized = false;
   if (opts.finalize) {
@@ -38,7 +38,7 @@ export async function merge(inputs: string[], opts: MergeOptions): Promise<Merge
 
   return {
     packs: { eligible: eligible.map((p) => p.run.run_id), skipped },
-    tests: { merged: union.length, collisions, discarded },
+    tests: { merged: groups.length, collisions, discarded },
     output: { path: opts.out, runId: opts.runId, finalized },
   };
 }

--- a/src/merge/rules.test.ts
+++ b/src/merge/rules.test.ts
@@ -22,6 +22,39 @@ describe("loadRules", () => {
     expect(r.rules).toHaveLength(1);
   });
 
+  it("parses an identity block; defaults leave it unset", async () => {
+    expect(DEFAULT_RULES.tests.identity).toBeUndefined();
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "evi-rules-"));
+    const p = path.join(tmp, "id.yaml");
+    await fs.writeFile(
+      p,
+      "tests:\n  on_collision: error\n  identity:\n    keys: [external_id.commit_id, external_id.test_id]\n    on_same: nest\n    on_different: split\n",
+    );
+    const r = await loadRules(p);
+    expect(r.tests.identity).toEqual({
+      keys: ["external_id.commit_id", "external_id.test_id"],
+      on_same: "nest",
+      on_different: "split",
+    });
+  });
+
+  it("rejects a malformed identity block as USAGE", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "evi-rules-"));
+    const cases = [
+      "tests: { identity: { keys: [], on_same: nest, on_different: split } }", // empty keys
+      "tests: { identity: { keys: [k], on_same: split, on_different: split } }", // split is not a same-action
+      "tests: { identity: { keys: [k], on_same: nest, on_different: nest } }", // nest is not a different-action
+      "tests: { identity: { keys: [k], on_same: nest, on_different: split, typo: 1 } }", // unknown key
+      "tests: { identity: { keys: [k], on_same: nest } }", // on_different missing
+      "tests: { identity: { keys: [''], on_same: nest, on_different: split } }", // empty key path
+    ];
+    for (const [i, c] of cases.entries()) {
+      const p = path.join(tmp, `bad-id-${i}.yaml`);
+      await fs.writeFile(p, c);
+      await expect(loadRules(p)).rejects.toMatchObject({ code: "USAGE" });
+    }
+  });
+
   it("rejects bad YAML, bad shape, and scope/action mismatch as USAGE", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "evi-rules-"));
     const cases = [

--- a/src/merge/rules.ts
+++ b/src/merge/rules.ts
@@ -6,6 +6,20 @@ import { parseYaml } from "../yaml";
 
 export type PackAction = "abort" | "skip";
 export type CollisionAction = "error" | "prefer_first" | "prefer_latest" | "discard";
+export type SameAction = "nest" | "prefer_latest" | "prefer_first" | "error";
+export type DifferentAction = "split" | "error";
+
+/**
+ * Optional identity policy (decision 0046). `keys` are dot-paths into
+ * result.yaml naming what makes two copies of a test id THE SAME test; the
+ * caller owns that vocabulary — evidence-cli never interprets a key and ships
+ * no default set. Absent, merge behaves exactly as 0045 specifies.
+ */
+export interface IdentityPolicy {
+  keys: string[];
+  on_same: SameAction;
+  on_different: DifferentAction;
+}
 
 export interface KeyRule {
   file: "run.yaml" | "result.yaml";
@@ -16,7 +30,7 @@ export interface KeyRule {
 
 export interface MergeRules {
   packs: { require_status: "finalized" | "running" | "any"; require_valid: "L0" | "L1" | "off"; on_ineligible: PackAction };
-  tests: { on_collision: CollisionAction };
+  tests: { on_collision: CollisionAction; identity?: IdentityPolicy };
   rules: KeyRule[];
 }
 

--- a/src/merge/testkit.ts
+++ b/src/merge/testkit.ts
@@ -13,6 +13,7 @@ import { parseYaml } from "../yaml";
 export interface StageTestSpec {
   status?: string; // test verdict; the 2-pay step carries the same status
   environment?: any; // result-level environment block
+  externalId?: any; // result-level external_id block (open map)
   failure?: string; // content of steps/2-pay/failure.yaml
 }
 
@@ -49,6 +50,7 @@ export async function stagePack(spec: StagePackSpec): Promise<string> {
     const status = t.status ?? "passed";
     let result = `evidence: "0.1"\ntest: ${id}\nstatus: ${status}\ndefinition:\n  path: test.md\nsteps:\n  - { id: open, ordinal: 1, status: passed }\n  - { id: pay, ordinal: 2, status: ${status} }\n`;
     if (t.environment) result += `environment: ${JSON.stringify(t.environment)}\n`;
+    if (t.externalId) result += `external_id: ${JSON.stringify(t.externalId)}\n`;
     await fs.writeFile(path.join(testDir, "result.yaml"), result);
 
     if (spec.l1) {

--- a/src/report/reporter.test.ts
+++ b/src/report/reporter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { JsonReporter, HumanReporter } from "./reporter";
-import type { ValidationReport } from "../contract";
+import type { MergeReport, ValidationReport } from "../contract";
 
 const REPORT: ValidationReport = {
   valid: false,
@@ -43,6 +43,26 @@ describe("reporters", () => {
   it("HumanReporter (TTY) uses the ✗ glyph", () => {
     const out = capture(() => new HumanReporter(true).validation(REPORT));
     expect(out).toContain("✗");
+  });
+
+  it("HumanReporter names the folder for nest and split outcomes", () => {
+    const merged: MergeReport = {
+      packs: { eligible: ["a", "b", "c"], skipped: [] },
+      tests: {
+        merged: 2,
+        collisions: [
+          { test: "checkout", winner: "b", rule: "tests.identity.on_same=nest", action: "nest", folder: "checkout" },
+          { test: "checkout", winner: "c", rule: "tests.identity.on_different=split", action: "split", folder: "checkout-1" },
+          { test: "login", winner: "a", rule: "tests.on_collision=prefer_first" },
+        ],
+        discarded: [],
+      },
+      output: { path: "/out/m.evidence", runId: "nightly", finalized: false },
+    };
+    const out = capture(() => new HumanReporter(false).merge(merged));
+    expect(out).toContain("collision checkout: nested into checkout, latest b [tests.identity.on_same=nest]");
+    expect(out).toContain("collision checkout: split into checkout-1 [tests.identity.on_different=split]");
+    expect(out).toContain("collision login: winner a [tests.on_collision=prefer_first]"); // unchanged
   });
 
   it("HumanReporter surfaces the pack's current status", () => {

--- a/src/report/reporter.ts
+++ b/src/report/reporter.ts
@@ -67,7 +67,10 @@ export class HumanReporter implements Reporter {
       process.stdout.write(this.paint(`${this.sym("warning")} skipped pack "${s.runId}": ${s.reason} [${s.rule}]`, "warning") + "\n");
     }
     for (const c of report.tests.collisions) {
-      const outcome = c.winner ? `winner ${c.winner}` : "discarded";
+      let outcome: string;
+      if (c.action === "nest") outcome = `nested into ${c.folder}, latest ${c.winner}`;
+      else if (c.action === "split") outcome = `split into ${c.folder}`;
+      else outcome = c.winner ? `winner ${c.winner}` : "discarded";
       process.stdout.write(`  collision ${c.test}: ${outcome} [${c.rule}]\n`);
     }
     if (report.tests.discarded.length > 0) {

--- a/src/schemas/merge-rules.schema.json
+++ b/src/schemas/merge-rules.schema.json
@@ -29,6 +29,22 @@
         "on_collision": {
           "description": "Default policy when two packs carry the same test id and no result.yaml rule fires. discard tombstones the id.",
           "enum": ["error", "prefer_first", "prefer_latest", "discard"]
+        },
+        "identity": {
+          "description": "Optional identity policy (decision 0046). Runs only when no result.yaml rule fired, so guard rules still abort first. `keys` name what makes two copies of a test id THE SAME test — the caller's vocabulary; evidence-cli never interprets a key. Same identity resolves by on_same (nest keeps every copy: latest canonical, superseded archived as 1/, 2/ …); different identity by on_different (split allocates a suffixed sibling folder).",
+          "type": "object",
+          "required": ["keys", "on_same", "on_different"],
+          "properties": {
+            "keys": {
+              "description": "Dot-paths into the parsed result.yaml, compared by canonical deep equality. Absent==absent counts as same, matching the generic rules.",
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "on_same": { "enum": ["nest", "prefer_latest", "prefer_first", "error"] },
+            "on_different": { "enum": ["split", "error"] }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## What

An optional `tests.identity` block in merge-rules turns a test-id collision from *"pick one winner"* into *"group by identity"*.

```yaml
tests:
  on_collision: error                 # unchanged fallback
  identity:
    keys: [external_id.commit_id, external_id.test_id]
    on_same: nest
    on_different: split
```

- **Same identity** → the latest run holds the canonical `tests/<id>/` exactly as an uncontested test does; superseded runs are archived whole beneath it as `1/`, `2/` … oldest first.
- **Different identity** → the copy gets its own sibling `tests/<id>-1/`, `-2/`.

**Purely additive.** Absent the block, output is unchanged — there is a regression test asserting exactly that.

```
merged/tests/
  login-flow/              result.yaml (latest) + steps/ logs/
    1/                     oldest superseded run, whole tree
    2/
  login-flow-1/            distinct test — result.yaml `test:` rewritten
```

## Why

Producers derive test ids (a slug plus a path hash), so merging two runs of the same suite collides on *every* test. `prefer_latest` answers that by discarding artifacts and `discard` by dropping the test outright — neither preserves history, and neither can tell "the same test, run again" apart from "two different tests that happen to share a derived name". This realises the slice 0045 deferred as *"cross-environment matrix identity"*.

## Design notes

- **Why a block, not a `split` action on the rule list.** Grouping must ask *"does this challenger belong to group 0, group 1, or neither?"*, which needs the whole key set as an up-front fact. Scraping it from "every rule whose action is `split`" would make identity an emergent property of an unrelated ordering — adding a guard rule would silently redefine sameness.
- **Why not new `on_collision` values.** `error`/`prefer_first`/`prefer_latest`/`discard` all answer *which copy survives* and never change the pack's shape. `nest`/`split` answer *what shape the output takes*.
- **Guard rules still resolve first**, so a `must: same` + `error` rule can never be downgraded into a split. `discard` tombstones the **base id** — split siblings included.
- **Suffix reservation** runs against every eligible pack's test ids, so a split never steals a name a pack legitimately owns (`<id>-1` taken → allocates `-2`).
- **Nested copies are inert by construction**, not special-casing: totals walk top-level `tests/*`, the failure index reads `tests/<id>/steps/`, L1 checks enumerate `<test>/steps/`.
- **Vendor-neutral per 0002** — `keys` are caller-supplied dot-paths; no producer field name enters `src/` or the schemas.

## Implementation

`collide.ts` generalises the union walk from one incumbent per test id to an ordered list of groups. A single-member group with `folder === baseId` *is* 0045's behaviour, so there is one code path rather than two. `assemble.ts` writes canonical + nested copies, rewrites `test` on split folders only (0031's directory equality), and pushes divergent environment down into every copy from its own source pack.

## Also in this PR

- **`src/design-links.test.ts`** — 0046 initially shipped without `governs`/`feature`, which made it invisible to the design viewer everywhere except the decisions log; it was the only one of 46 decisions missing them. The new test catches the class. Note it revealed that a `governs` entry may be a conceptual *area* (`repo` in 0001/0025) rather than a path, so only path-shaped entries are filesystem-checked.
- **CHANGELOG backfill for 0.1.6** — published to npm but never documented, leaving a hole between 0.1.5 and this release.

## Verification

- `npx vitest run` → **194 passed / 20 files**
- `npm run build` → clean
- Docs site rebuilt; 0046 now resolves against `Contract.tsx`'s `design/contract/03-commands.md` token

## Note for consumers

`on_same: nest` **retains artifacts that `prefer_latest` discards today**, so merged packs of re-runs grow with the number of runs kept. That is the intent of the feature, but it is a real change in output size for anyone who opts in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)