### PR TITLE
site: lead the hero with a large .evidence format mark

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -51,6 +51,10 @@
       <!-- ============ HERO ============ -->
       <section class="hero">
         <div class="wrap">
+          <div class="hero-mark" aria-label="The .evidence format">
+            <span class="hero-mark-dot"></span>
+            <span class="hero-mark-ext"><span class="dotpart">.</span>evidence</span>
+          </div>
           <span class="pill"
             ><span class="spark">◆</span> Open format · Apache-2.0 · framework-agnostic</span
           >

--- a/site/styles.css
+++ b/site/styles.css
@@ -202,6 +202,45 @@ h2 {
   text-align: center;
   border-bottom: 1px solid rgba(255, 255, 255, 0.045);
 }
+
+/* The .evidence format mark — the hero's signature, a large file-extension token. */
+.hero-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 22px 12px 18px;
+  margin-bottom: 26px;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background:
+    radial-gradient(120px 60px at 20% 0%, rgba(139, 92, 246, 0.22), transparent 70%),
+    rgba(0, 0, 0, 0.3);
+  box-shadow: 0 18px 50px -26px rgba(139, 92, 246, 0.7);
+}
+.hero-mark-dot {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--brand), var(--warm));
+  box-shadow: 0 0 18px rgba(139, 92, 246, 0.8);
+  flex: none;
+}
+.hero-mark-ext {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: clamp(26px, 5vw, 40px);
+  letter-spacing: -0.02em;
+  line-height: 1;
+  background: linear-gradient(120deg, var(--brand-3), var(--brand), var(--warm));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.hero-mark-ext .dotpart {
+  color: var(--faint);
+  -webkit-text-fill-color: var(--faint);
+}
+
 .pill {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Surfaces the format name at the very top of the landing hero: a large gradient
monospace **`.evidence`** token with a brand dot, above the headline — so the
format itself is the first thing you see.

- Stacks cleanly above the "Open format" pill on narrow widths (verified at desktop and 500px).
- Site-only change: `site/index.html` + `site/styles.css` (+43 lines). No other files touched.

Follow-up to #14 (which is already merged); this is the one remaining site change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)